### PR TITLE
Use melos to handle monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ gradlew.bat
 .project
 .classpath
 .settings
+
+# Melos
+**/pubspec_overrides.yaml

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,0 +1,26 @@
+name: flutter-passkeys
+repository: https://github.com/corbado/flutter-passkeys
+packages:
+  - packages/**
+
+scripts:
+  format:
+    description: Format Dart code.
+    run: dart format .
+
+  format:check:
+    description: Check formatting of Dart code.
+    run: dart format --output none --set-exit-if-changed .
+
+  analyze:
+    description: Analyze Dart code.
+    run: dart analyze . --fatal-infos
+
+  test:
+    description: Run tests in a specific package.
+    run: dart test
+    exec:
+      concurrency: 1
+    packageFilters:
+      dirExists:
+        - test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,7 @@
+name: futter_passkeys_workspace
+
+environment:
+  sdk: '>=2.18.0 <4.0.0'
+
+dev_dependencies:
+  melos: any


### PR DESCRIPTION
Add support for [melos](https://melos.invertase.dev/) to make it easy to setup dependency overrides.
```sh
dart pub global activate melos # one-time setup to activate melos
```
Now add `~/.pub-cache/bin` if you haven't already.

To setup dependency overrides run `melos bootstrap`,

Also added a few common scrips:
```sh
melos analyze
melos format:check
melos test
```
and `melos format`, but be aware that the last will format all your code with `dart format`. It seems you are currently working with another linelength than 80.