### PR TITLE
fixing issue with excludeCredentials on iOS < 17.4

### DIFF
--- a/packages/passkeys/passkeys_ios/ios/Classes/PasskeysPlugin.swift
+++ b/packages/passkeys/passkeys_ios/ios/Classes/PasskeysPlugin.swift
@@ -52,8 +52,10 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
             name: user.name,
             userID: decodedUserId
         )
-                
-        request.excludedCredentials = parseCredentials(credentialIDs: excludeCredentialIDs)
+
+        if #available(iOS 17.4, *) {
+            request.excludedCredentials = parseCredentials(credentialIDs: excludeCredentialIDs)
+        }
 
         func wrappedCompletion(result: Result<RegisterResponse, Error>) {
             lock.unlock()


### PR DESCRIPTION
It seems that excludeCredentials is only available on iOS 17.4+ and builds are failing for targets under that without this exclusion statement