### PR TITLE
Upgraded androidx.credentials:credentials-play-services-auth and andr…

### DIFF
--- a/packages/passkeys/passkeys_android/android/build.gradle
+++ b/packages/passkeys/passkeys_android/android/build.gradle
@@ -49,11 +49,11 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.annotation:annotation:1.6.0'
-    implementation("androidx.credentials:credentials:1.2.1")
+    implementation("androidx.credentials:credentials:1.2.2")
 
     // optional - needed for credentials support from play services, for devices running
     // Android 13 and below.0
-    implementation("androidx.credentials:credentials-play-services-auth:1.2.1")
+    implementation("androidx.credentials:credentials-play-services-auth:1.2.2")
     implementation 'com.google.android.gms:play-services-auth:20.5.0'
     implementation 'com.google.android.gms:play-services-fido:20.0.1'
     implementation 'androidx.multidex:multidex:2.0.1'


### PR DESCRIPTION
…oidx.credentials:credentials

Upgraded androidx.credentials:credentials-play-services-auth and androidx.credentials:credentials

to 1.2.2 version, lots of android devices were facing issues using passkey, upgrading to the latest version fixed this issue