### PR TITLE
Add a namespace for compatibility with AGP 8.0

### DIFF
--- a/packages/passkeys/passkeys_android/android/build.gradle
+++ b/packages/passkeys/passkeys_android/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for campatibility with AGP <4.2
+    if (project.android.hasProperty('namespace')) {
+        namespace 'com.corbado.passkeys_android'
+    }
     compileSdkVersion 34
 
     compileOptions {


### PR DESCRIPTION
Add a `namespace` attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.