### PR TITLE
Fix preferImmediatelyAvailableCredentials usage in iOS package

### DIFF
--- a/packages/passkeys/passkeys_ios/ios/Classes/AuthenticateController.swift
+++ b/packages/passkeys/passkeys_ios/ios/Classes/AuthenticateController.swift
@@ -20,13 +20,17 @@ class AuthenticateController: NSObject, ASAuthorizationControllerDelegate, ASAut
         if (conditionalUI) {
             authorizationController.performAutoFillAssistedRequests()
         } else {
-            authorizationController.performRequests(options: .preferImmediatelyAvailableCredentials)
+            if preferImmediatelyAvailableCredentials {
+                authorizationController.performRequests(options: .preferImmediatelyAvailableCredentials)
+            } else {
+                authorizationController.performRequests()
+            }
         }
 
         func cancel() {
             authorizationController.cancel();
         }
-        
+
         self.innerCancel = cancel
     }
     


### PR DESCRIPTION
### What does this PR do?
This PR fixes issue with `preferImmediatelyAvailableCredentials`.

- if we pass non-empty `AuthenticateRequestType.allowCredentials` and `AuthenticateRequestType.preferImmediatelyAvailableCredentials: false` to the `PasskeyAuthenticator().authenticate`, but current device doesn't have any of the `allowCredentials` the bevior:
  * current: we get "no credentials found" exception
  * expected: the system should show a dialog with "other account" (like Chrome) and other device (QR code)