### PR TITLE
Integrate namespace to build.gradle to allow AGP8+

### DIFF
--- a/packages/passkeys/passkeys/example/android/app/build.gradle
+++ b/packages/passkeys/passkeys/example/android/app/build.gradle
@@ -43,7 +43,7 @@ android {
 
     defaultConfig {
         applicationId "com.corbado.passkeys.pub"
-        minSdkVersion 21
+        minSdkVersion 28
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/passkeys/passkeys_android/android/build.gradle
+++ b/packages/passkeys/passkeys_android/android/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'kotlin-android'
 def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION ?: com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
 
 android {
-    if (agpVersion <= "7.0") {
+    if (agpVersion >= "7.0") {
         namespace 'com.corbado.passkeys_android'
     }
 

--- a/packages/passkeys/passkeys_android/android/build.gradle
+++ b/packages/passkeys/passkeys_android/android/build.gradle
@@ -24,13 +24,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-// Detect AGP version
-// Using both `com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION` and `com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION`
-// for backward compatibility. The first is available in newer AGP versions, while the second supports older AGP versions.
-def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION ?: com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
-
 android {
-    if (agpVersion >= "7.0") {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
         namespace 'com.corbado.passkeys_android'
     }
 

--- a/packages/passkeys/passkeys_android/android/build.gradle
+++ b/packages/passkeys/passkeys_android/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 // Detect AGP version
+// Using both `com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION` and `com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION`
+// for backward compatibility. The first is available in newer AGP versions, while the second supports older AGP versions.
 def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION ?: com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
 
 android {

--- a/packages/passkeys/passkeys_android/android/build.gradle
+++ b/packages/passkeys/passkeys_android/android/build.gradle
@@ -24,7 +24,14 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+// Detect AGP version
+def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION ?: com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
+
 android {
+    if (agpVersion <= "7.0") {
+        namespace 'com.corbado.passkeys_android'
+    }
+
     compileSdkVersion 34
 
     compileOptions {


### PR DESCRIPTION
This is a continuation of this previous [PR](https://github.com/corbado/flutter-passkeys/pull/64) to improve the AGP version detection when integrating the namespace.