### PR TITLE
Fix preferImmediatelyAvailableCredentials usage in iOS package

### DIFF
--- a/packages/passkeys/passkeys_ios/ios/Classes/AuthenticateController.swift
+++ b/packages/passkeys/passkeys_ios/ios/Classes/AuthenticateController.swift
@@ -20,13 +20,17 @@ class AuthenticateController: NSObject, ASAuthorizationControllerDelegate, ASAut
         if (conditionalUI) {
             authorizationController.performAutoFillAssistedRequests()
         } else {
-            authorizationController.performRequests(options: .preferImmediatelyAvailableCredentials)
+            if preferImmediatelyAvailableCredentials {
+                authorizationController.performRequests(options: .preferImmediatelyAvailableCredentials)
+            } else {
+                authorizationController.performRequests()
+            }
         }
 
         func cancel() {
             authorizationController.cancel();
         }
-        
+
         self.innerCancel = cancel
     }
     

--- a/packages/passkeys/passkeys_ios/ios/Classes/AuthenticateController.swift
+++ b/packages/passkeys/passkeys_ios/ios/Classes/AuthenticateController.swift
@@ -20,6 +20,9 @@ class AuthenticateController: NSObject, ASAuthorizationControllerDelegate, ASAut
         if (conditionalUI) {
             authorizationController.performAutoFillAssistedRequests()
         } else {
+            // The `.preferImmediatelyAvailableCredentials` option in `ASAuthorizationController`
+            // does not distinguish between `true` and `false` values. If the option is included
+            // in the `options` parameter, iOS assumes the behavior is enabled.
             if preferImmediatelyAvailableCredentials {
                 authorizationController.performRequests(options: .preferImmediatelyAvailableCredentials)
             } else {


### PR DESCRIPTION
This is a continuation of this [PR](https://github.com/corbado/flutter-passkeys/pull/83)