### PR TITLE
Add ble to AuthenticatorTransport enum

### DIFF
--- a/packages/passkeys/passkeys_web/lib/models/passkeyLoginRequest.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkeyLoginRequest.dart
@@ -98,7 +98,9 @@ enum AuthenticatorTransport {
   @JsonValue('usb')
   Usb,
   @JsonValue('bluetooth')
-  Bluetooth;
+  Bluetooth,
+  @JsonValue('ble')
+  BluetoothLowEnergy;
 
   factory AuthenticatorTransport.fromPlatformType(String value) {
     switch (value) {
@@ -112,6 +114,8 @@ enum AuthenticatorTransport {
         return AuthenticatorTransport.Nfc;
       case 'bluetooth':
         return AuthenticatorTransport.Bluetooth;
+      case 'ble':
+        return AuthenticatorTransport.BluetoothLowEnergy;
       default:
         throw ArgumentError.value(value);
     }

--- a/packages/passkeys/passkeys_web/lib/models/passkeyLoginRequest.g.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkeyLoginRequest.g.dart
@@ -89,6 +89,7 @@ const _$AuthenticatorTransportEnumMap = {
   AuthenticatorTransport.Nfc: 'nfc',
   AuthenticatorTransport.Usb: 'usb',
   AuthenticatorTransport.Bluetooth: 'bluetooth',
+  AuthenticatorTransport.BluetoothLowEnergy: 'ble',
 };
 
 LoginExtensions _$LoginExtensionsFromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
BLE is the [standard enum value](https://www.w3.org/TR/webauthn-2/#enum-transport). Keeping bluetooth just for backward compatibility.