### PR TITLE
fix: Avoid JSValue is not a String exception when building wasm

### DIFF
--- a/packages/passkeys/passkeys_web/lib/passkeys_web.dart
+++ b/packages/passkeys/passkeys_web/lib/passkeys_web.dart
@@ -23,8 +23,7 @@ class PasskeysWeb extends PasskeysPlatform {
       final _ = window['PasskeyAuthenticator'];
     } catch (_) {
       debugPrint(
-        'Error: Passkeys Web SDK not loaded. Please include the Passkeys Web SDK (bundle.js) in your HTML file. You can find it on https://github.com/corbado/flutter-passkeys/releases/download/2.4.0/bundle.js',
-      );
+          'Error: Passkeys Web SDK not loaded. Please include the Passkeys Web SDK (bundle.js) in your HTML file. You can find it on https://github.com/corbado/flutter-passkeys/releases/download/2.4.0/bundle.js');
       // We need to close the window to prevent the app from running afterwards thus causing runtime errors
       // This is a workaround for the fact that we cannot throw an exception in the web platform
       // because it will not be caught by the Flutter framework
@@ -50,9 +49,8 @@ class PasskeysWeb extends PasskeysPlatform {
 
     try {
       final serializedRequest = jsonEncode(r.toJson());
-      final response = await authenticatorRegister(
-        serializedRequest.toJS,
-      ).toDart;
+      final response =
+          await authenticatorRegister(serializedRequest.toJS).toDart;
       final decodedResponse =
           jsonDecode(response.toDart) as Map<String, dynamic>;
       final typedResponse = PasskeySignUpResponse.fromJson(decodedResponse);
@@ -72,8 +70,7 @@ class PasskeysWeb extends PasskeysPlatform {
 
   @override
   Future<AuthenticateResponseType> authenticate(
-    AuthenticateRequestType request,
-  ) async {
+      AuthenticateRequestType request) async {
     final r = PasskeyLoginRequest.fromPlatformType(
       request.relyingPartyId,
       request.challenge,
@@ -126,9 +123,8 @@ class PasskeysWeb extends PasskeysPlatform {
 
     return AvailabilityTypeWeb(
       hasPasskeySupport: passkeySupport,
-      isUserVerifyingPlatformAuthenticatorAvailable: v1.isUndefinedOrNull
-          ? null
-          : v1!.toDart,
+      isUserVerifyingPlatformAuthenticatorAvailable:
+          v1.isUndefinedOrNull ? null : v1!.toDart,
       isConditionalMediationAvailable: v2.isUndefinedOrNull ? null : v2!.toDart,
       isNative: false,
     );


### PR DESCRIPTION
When building for wasm, `parseException(e as String)` calls fail due to `e` being a `JSValue` which is not a `String`.

This PR replaces `as String` with `.toString()`, which avoids this issue.