### PR TITLE
Fix Base64URL encoding truncation in Windows WebAuthn helper

### DIFF
--- a/packages/passkeys/passkeys_windows/windows/webauthn_helper.cpp
+++ b/packages/passkeys/passkeys_windows/windows/webauthn_helper.cpp
@@ -94,15 +94,24 @@ namespace passkeys_windows
     }
 
     std::string base64(base64_size, 0);
+    DWORD written_size = base64_size;
     if (!CryptBinaryToStringA(data, static_cast<DWORD>(size),
                               CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF,
-                              &base64[0], &base64_size))
+                              &base64[0], &written_size))
     {
       throw std::runtime_error("Failed to encode base64");
     }
 
-    // Remove null terminator
-    base64.resize(base64_size - 1);
+    // Resize to actual content length (excluding null terminator if present)
+    // CryptBinaryToStringA writes 'written_size' chars which may include null terminator
+    if (written_size > 0 && base64[written_size - 1] == '\0')
+    {
+      base64.resize(written_size - 1);
+    }
+    else
+    {
+      base64.resize(written_size);
+    }
 
     // Base64 to Base64url conversion
     for (char &c : base64)


### PR DESCRIPTION
### Problem
While implementing passkeys in a personal Windows project, I noticed the clientDataJSON Base64 encoding was sometimes missing the closing }.

### Root Cause
In EncodeBase64Url, the CryptBinaryToStringA function modifies the size parameter passed to it. The code was then subtracting 1 from this already-updated value:
```
if (!CryptBinaryToStringA(..., &base64_size)) // base64_size gets modified
base64.resize(base64_size - 1); // Wrong: subtracting 1 from updated value
```

This caused one character of actual content to be truncated. The bug appeared intermittently because the truncated character varied based on origin URL length—sometimes it was just padding, sometimes it was real content.

### Fix
Use a separate variable for the write operation and properly check for null terminator before removing it.