### PR TITLE
feat: Add PRF support for iOS & Android

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -3,9 +3,6 @@ repository: https://github.com/corbado/flutter-passkeys
 packages:
   - packages/**
 
-command:
-  bootstrap:
-    usePubspecOverrides: true
 
 scripts:
   format:

--- a/packages/corbado_auth/pubspec.yaml
+++ b/packages/corbado_auth/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/corba
 version: 3.7.1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: '>=3.8.0 <4.0.0'
   flutter: ">=3.0.0"
 
 dependencies:
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   flutter_secure_storage: "<=9.0.0 >8.0.0"
   http: ^1.1.2
-  json_annotation: ^4.8.1
+  json_annotation: ^4.10.0
   jwt_decoder: ^2.0.1
   meta: ^1.15.0
   passkeys: ^2.13.0

--- a/packages/passkeys/passkeys/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/passkeys/passkeys/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>12.0</string>
+  <string>13.0</string>
 </dict>
 </plist>

--- a/packages/passkeys/passkeys/example/ios/Podfile
+++ b/packages/passkeys/passkeys/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/passkeys/passkeys/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/passkeys/passkeys/example/ios/Runner.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				1F5231B1C0B4B24BD6457DFB /* [CP] Embed Pods Frameworks */,
+				635C969084CC2623F9C369FA /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -234,6 +235,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		635C969084CC2623F9C369FA /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -347,7 +365,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -430,7 +448,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -479,7 +497,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/packages/passkeys/passkeys/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/passkeys/passkeys/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -43,6 +44,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/packages/passkeys/passkeys/lib/authenticator.dart
+++ b/packages/passkeys/passkeys/lib/authenticator.dart
@@ -40,7 +40,7 @@ class PasskeyAuthenticator {
   /// Creates a new passkey and stores it on the device.
   /// Returns [RegisterResponseType] which must be sent to the relying party
   /// server.
-  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async {
+  Future<RegisterResponseType> register(RegisterRequestType request, {String? salt}) async {
     if (debugMode) {
       await _doctor.check(request.relyingParty.id);
     }
@@ -108,7 +108,7 @@ class PasskeyAuthenticator {
         }
       }
 
-      final r = await _platform.authenticate(request, salt: salt);
+      final r = await _platform.authenticate(request, salt);
 
       return r;
     } on PlatformException catch (e) {

--- a/packages/passkeys/passkeys/lib/authenticator.dart
+++ b/packages/passkeys/passkeys/lib/authenticator.dart
@@ -9,9 +9,7 @@ import 'package:passkeys_platform_interface/passkeys_platform_interface.dart';
 /// flow.
 class PasskeyAuthenticator {
   /// Constructor
-  PasskeyAuthenticator({bool? debugMode})
-      : _platform = PasskeysPlatform.instance,
-        debugMode = debugMode ?? false;
+  PasskeyAuthenticator({bool? debugMode}) : _platform = PasskeysPlatform.instance, debugMode = debugMode ?? false;
 
   /// The [PasskeysDoctor] instance for debugging and checking passkeys
   final _doctor = PasskeysDoctor();
@@ -23,8 +21,10 @@ class PasskeyAuthenticator {
   final bool debugMode;
 
   /// Returns true only if passkeys are supported by the platform.
-  @Deprecated('Use PasskeyAvailability.isAvailable instead. '
-      'This method will be removed in a future release.')
+  @Deprecated(
+    'Use PasskeyAvailability.isAvailable instead. '
+    'This method will be removed in a future release.',
+  )
   Future<bool> canAuthenticate() {
     return _platform.canAuthenticate();
   }
@@ -40,7 +40,7 @@ class PasskeyAuthenticator {
   /// Creates a new passkey and stores it on the device.
   /// Returns [RegisterResponseType] which must be sent to the relying party
   /// server.
-  Future<RegisterResponseType> register(RegisterRequestType request) async {
+  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async {
     if (debugMode) {
       await _doctor.check(request.relyingParty.id);
     }
@@ -56,7 +56,7 @@ class PasskeyAuthenticator {
         _isValidCredentialID(credential.id);
       }
 
-      final r = await _platform.register(request);
+      final r = await _platform.register(request, salt);
 
       return r;
     } on PlatformException catch (e) {
@@ -92,9 +92,7 @@ class PasskeyAuthenticator {
   /// Authenticates a user with a passkey.
   /// Returns [AuthenticateResponseType] which must be sent to the relying party
   /// server.
-  Future<AuthenticateResponseType> authenticate(
-    AuthenticateRequestType request,
-  ) async {
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt}) async {
     if (debugMode) {
       await _doctor.check(request.relyingPartyId);
     }
@@ -110,7 +108,7 @@ class PasskeyAuthenticator {
         }
       }
 
-      final r = await _platform.authenticate(request);
+      final r = await _platform.authenticate(request, salt: salt);
 
       return r;
     } on PlatformException catch (e) {
@@ -174,9 +172,7 @@ class PasskeyAuthenticator {
   void _isValidChallenge(String challenge) {
     if (!_isValidBase64Url(input: challenge)) {
       if (debugMode) {
-        _doctor.recordException(
-          PlatformException(code: 'malformed-base64-url-challenge'),
-        );
+        _doctor.recordException(PlatformException(code: 'malformed-base64-url-challenge'));
       }
       throw MalformedBase64UrlChallenge();
     }
@@ -186,9 +182,7 @@ class PasskeyAuthenticator {
   void _isValidCredentialID(String credentialID) {
     if (!_isValidBase64Url(input: credentialID)) {
       if (debugMode) {
-        _doctor.recordException(
-          PlatformException(code: 'malformed-base64-url-credential-id'),
-        );
+        _doctor.recordException(PlatformException(code: 'malformed-base64-url-credential-id'));
       }
       throw MalformedBase64UrlCredentialID();
     }
@@ -198,9 +192,7 @@ class PasskeyAuthenticator {
   void _isValidUserID(String userID) {
     if (!_isValidBase64Url(input: userID, allowPadding: true)) {
       if (debugMode) {
-        _doctor.recordException(
-          PlatformException(code: 'malformed-base64-url-user-id'),
-        );
+        _doctor.recordException(PlatformException(code: 'malformed-base64-url-user-id'));
       }
       throw MalformedBase64UrlUserID();
     }
@@ -227,8 +219,7 @@ class PasskeyAuthenticator {
     if (!base64UrlRegex.hasMatch(input)) return false;
 
     try {
-      String normalized =
-          input.padRight(input.length + (4 - input.length % 4) % 4, '=');
+      String normalized = input.padRight(input.length + (4 - input.length % 4) % 4, '=');
       base64Url.decode(normalized);
 
       return true;

--- a/packages/passkeys/passkeys/pubspec.yaml
+++ b/packages/passkeys/passkeys/pubspec.yaml
@@ -3,6 +3,7 @@ description: Flutter plugin enabling simple passkey authentication. Can be eithe
 homepage: https://docs.corbado.com/overview/welcome
 repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passkeys/passkeys
 version: 2.17.4
+resolution: workspace
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/passkeys/passkeys/pubspec.yaml
+++ b/packages/passkeys/passkeys/pubspec.yaml
@@ -3,9 +3,10 @@ description: Flutter plugin enabling simple passkey authentication. Can be eithe
 homepage: https://docs.corbado.com/overview/welcome
 repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passkeys/passkeys
 version: 2.17.4
+publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: '>=3.8.0 <4.0.0'
   flutter: ">=3.0.0"
 
 flutter:
@@ -27,12 +28,18 @@ dependencies:
   flutter:
     sdk: flutter
   json_annotation: ^4.8.1
-  passkeys_android: ^2.11.0
-  passkeys_darwin: ^0.3.0
-  passkeys_doctor: ^1.2.0
-  passkeys_platform_interface: ^2.6.0
-  passkeys_web: ^2.8.1
-  passkeys_windows: ^0.1.1
+  passkeys_android: 
+    path: ../passkeys_android
+  passkeys_darwin: 
+    path: ../passkeys_darwin
+  passkeys_doctor: 
+    path: ../passkeys_doctor
+  passkeys_platform_interface:
+    path: ../passkeys_platform_interface
+  passkeys_web: 
+    path: ../passkeys_web
+  passkeys_windows: 
+    path: ../passkeys_windows
   ua_client_hints: ^1.1.3
 
 dev_dependencies:
@@ -43,3 +50,7 @@ dev_dependencies:
   mocktail: ^1.0.0
   plugin_platform_interface: ^2.0.0
   very_good_analysis: ^5.0.0
+  
+dependency_overrides:
+  passkeys_platform_interface:
+    path: ../passkeys_platform_interface

--- a/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
+++ b/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
@@ -130,10 +130,9 @@ public class MessageHandler implements Messages.PasskeysApi {
         try {
             JSONObject optionsJson = createCredentialOptions.toJSON();
 
-            // Add PRF extension if salt provided
+            // PRF extension if salt provided
             if (salt != null && !salt.isEmpty()) {
                 String saltBase64Url = hexToBase64Url(salt);
-                Log.i("Passkey", "salt provided" + saltBase64Url);
                 JSONObject extensions = optionsJson.optJSONObject("extensions");
                 if (extensions == null) extensions = new JSONObject();
 
@@ -164,7 +163,6 @@ public class MessageHandler implements Messages.PasskeysApi {
                             try {
                                 JSONObject json = new JSONObject(resp);
                                 JSONObject response = json.getJSONObject("response");
-                                Log.i("Passkeys", "json = " + json);
 
                                 // Note: The "transports" field can be optional in the authenticator response.
                                 // While the WebAuthn spec
@@ -184,8 +182,6 @@ public class MessageHandler implements Messages.PasskeysApi {
 
                                 JSONObject ext = json.optJSONObject("clientExtensionResults");
                                 Map<String, Object> extMap = null;
-
-                                Log.i("Passkeys", "extension = " + ext);
 
                                 if (ext != null) {
                                     extMap = new HashMap<>();
@@ -286,7 +282,7 @@ public class MessageHandler implements Messages.PasskeysApi {
                 allowCredentialsType, userVerification);
         try {
             JSONObject optionsJson = getCredentialOptions.toJSON();
-// Add      PRF extension if salt provided
+            // PRF extension if salt provided
             if (salt != null && !salt.isEmpty()) {
                 String saltBase64Url = hexToBase64Url(salt);
                 Log.i("Passkey", "salt provided auth" + saltBase64Url);
@@ -343,8 +339,6 @@ public class MessageHandler implements Messages.PasskeysApi {
 
                                     JSONObject ext = json.optJSONObject("clientExtensionResults");
                                     Map<String, Object> extMap = null;
-
-                                    Log.i("Passkeys", "extension = " + ext);
 
                                     if (ext != null) {
                                         extMap = new HashMap<>();

--- a/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
+++ b/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
@@ -191,13 +191,10 @@ public class MessageHandler implements Messages.PasskeysApi {
                                         JSONObject results = prf.optJSONObject("results");
                                         if (results != null) {
                                             String first = results.optString("first", "");
-
                                             Map<String, Object> resultsMap = new HashMap<>();
                                             resultsMap.put("first", first);
-
                                             Map<String, Object> prfMap = new HashMap<>();
                                             prfMap.put("results", resultsMap);
-
                                             extMap.put("prf", prfMap);
                                         }
                                     }
@@ -348,13 +345,10 @@ public class MessageHandler implements Messages.PasskeysApi {
                                             JSONObject results = prf.optJSONObject("results");
                                             if (results != null) {
                                                 String first = results.optString("first", "");
-
                                                 Map<String, Object> resultsMap = new HashMap<>();
                                                 resultsMap.put("first", first);
-
                                                 Map<String, Object> prfMap = new HashMap<>();
                                                 prfMap.put("results", resultsMap);
-
                                                 extMap.put("prf", prfMap);
                                             }
                                         }
@@ -430,11 +424,9 @@ public class MessageHandler implements Messages.PasskeysApi {
     public static String hexToBase64Url(String hex) {
         int len = hex.length();
         byte[] bytes = new byte[len / 2];
-
         for (int i = 0; i < len; i += 2) {
             bytes[i / 2] = (byte) Integer.parseInt(hex.substring(i, i + 2), 16);
         }
-
         return Base64.encodeToString(
                 bytes,
                 Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP

--- a/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
+++ b/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
@@ -2,6 +2,7 @@ package com.corbado.passkeys_android;
 
 import android.app.Activity;
 import android.os.CancellationSignal;
+import android.util.Base64;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -41,7 +42,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -89,7 +92,9 @@ public class MessageHandler implements Messages.PasskeysApi {
             @Nullable Long timeout,
             @Nullable String attestation,
             @NonNull List<Messages.ExcludeCredential> excludeCredentials,
-            @NonNull Messages.Result<Messages.RegisterResponse> result) {
+            @Nullable String salt,
+            @NonNull Messages.Result<Messages.RegisterResponse> result
+            ) {
         if (android.os.Build.VERSION.SDK_INT < 28) {
             result.error(new Messages.FlutterError("android-passkey-unsupported",
                     "Passkeys are only supported on Android API 28 and above.", null));
@@ -123,7 +128,25 @@ public class MessageHandler implements Messages.PasskeysApi {
                 excludeCredentialsType);
 
         try {
-            String options = createCredentialOptions.toJSON().toString();
+            JSONObject optionsJson = createCredentialOptions.toJSON();
+
+            // Add PRF extension if salt provided
+            if (salt != null && !salt.isEmpty()) {
+                String saltBase64Url = hexToBase64Url(salt);
+                Log.i("Passkey", "salt provided" + saltBase64Url);
+                JSONObject extensions = optionsJson.optJSONObject("extensions");
+                if (extensions == null) extensions = new JSONObject();
+
+                JSONObject prf = new JSONObject();
+                JSONObject eval = new JSONObject();
+                eval.put("first", saltBase64Url);
+                prf.put("eval", eval);
+
+                extensions.put("prf", prf);
+                optionsJson.put("extensions", extensions);
+            }
+            String options = optionsJson.toString();
+            Log.i("Passkeys", "options = " + options);
 
             Activity activity = plugin.requireActivity();
             CredentialManager credentialManager = CredentialManager.create(activity);
@@ -141,6 +164,7 @@ public class MessageHandler implements Messages.PasskeysApi {
                             try {
                                 JSONObject json = new JSONObject(resp);
                                 JSONObject response = json.getJSONObject("response");
+                                Log.i("Passkeys", "json = " + json);
 
                                 // Note: The "transports" field can be optional in the authenticator response.
                                 // While the WebAuthn spec
@@ -158,12 +182,37 @@ public class MessageHandler implements Messages.PasskeysApi {
                                     typedTransports.add("");
                                 }
 
+                                JSONObject ext = json.optJSONObject("clientExtensionResults");
+                                Map<String, Object> extMap = null;
+
+                                Log.i("Passkeys", "extension = " + ext);
+
+                                if (ext != null) {
+                                    extMap = new HashMap<>();
+
+                                    JSONObject prf = ext.optJSONObject("prf");
+                                    if (prf != null) {
+                                        JSONObject results = prf.optJSONObject("results");
+                                        if (results != null) {
+                                            String first = results.optString("first", "");
+
+                                            Map<String, Object> resultsMap = new HashMap<>();
+                                            resultsMap.put("first", first);
+
+                                            Map<String, Object> prfMap = new HashMap<>();
+                                            prfMap.put("results", resultsMap);
+
+                                            extMap.put("prf", prfMap);
+                                        }
+                                    }
+                                }
                                 result.success(new Messages.RegisterResponse.Builder()
                                         .setId(json.getString("id"))
                                         .setRawId(json.getString("rawId"))
                                         .setClientDataJSON(response.getString("clientDataJSON"))
                                         .setAttestationObject(response.getString("attestationObject"))
                                         .setTransports(typedTransports)
+                                        .setClientExtensionResults(extMap)
                                         .build());
                             } catch (JSONException e) {
                                 Log.e(TAG, "Error parsing response: " + resp, e);
@@ -219,6 +268,7 @@ public class MessageHandler implements Messages.PasskeysApi {
     public void authenticate(@NonNull String relyingPartyId, @NonNull String challenge, @Nullable Long timeout,
             @Nullable String userVerification, @Nullable List<Messages.AllowCredential> allowCredentials,
             @Nullable Boolean preferImmediatelyAvailableCredentials,
+            @Nullable String salt,
             @NonNull Messages.Result<Messages.AuthenticateResponse> result) {
         if (android.os.Build.VERSION.SDK_INT < 28) {
             result.error(new Messages.FlutterError("android-passkey-unsupported",
@@ -235,8 +285,24 @@ public class MessageHandler implements Messages.PasskeysApi {
         GetCredentialOptions getCredentialOptions = new GetCredentialOptions(challenge, timeout, relyingPartyId,
                 allowCredentialsType, userVerification);
         try {
-            String options = getCredentialOptions.toJSON().toString();
+            JSONObject optionsJson = getCredentialOptions.toJSON();
+// Add      PRF extension if salt provided
+            if (salt != null && !salt.isEmpty()) {
+                String saltBase64Url = hexToBase64Url(salt);
+                Log.i("Passkey", "salt provided auth" + saltBase64Url);
+                JSONObject extensions = optionsJson.optJSONObject("extensions");
+                if (extensions == null) extensions = new JSONObject();
 
+                JSONObject prf = new JSONObject();
+                JSONObject eval = new JSONObject();
+                eval.put("first", saltBase64Url);
+                prf.put("eval", eval);
+
+                extensions.put("prf", prf);
+                optionsJson.put("extensions", extensions);
+            }
+            String options = optionsJson.toString();
+            Log.i("Passkeys", "options = " + options);
             Activity activity = plugin.requireActivity();
 
             CredentialManager credentialManager = CredentialManager.create(activity);
@@ -275,9 +341,35 @@ public class MessageHandler implements Messages.PasskeysApi {
                                     final String signature = response.getString("signature");
                                     final String authenticatorData = response.getString("authenticatorData");
 
+                                    JSONObject ext = json.optJSONObject("clientExtensionResults");
+                                    Map<String, Object> extMap = null;
+
+                                    Log.i("Passkeys", "extension = " + ext);
+
+                                    if (ext != null) {
+                                        extMap = new HashMap<>();
+
+                                        JSONObject prf = ext.optJSONObject("prf");
+                                        if (prf != null) {
+                                            JSONObject results = prf.optJSONObject("results");
+                                            if (results != null) {
+                                                String first = results.optString("first", "");
+
+                                                Map<String, Object> resultsMap = new HashMap<>();
+                                                resultsMap.put("first", first);
+
+                                                Map<String, Object> prfMap = new HashMap<>();
+                                                prfMap.put("results", resultsMap);
+
+                                                extMap.put("prf", prfMap);
+                                            }
+                                        }
+                                    }
                                     final Messages.AuthenticateResponse msg = new Messages.AuthenticateResponse.Builder()
                                             .setId(id).setRawId(rawId).setClientDataJSON(clientDataJSON)
-                                            .setAuthenticatorData(authenticatorData).setSignature(signature)
+                                            .setAuthenticatorData(authenticatorData)
+                                            .setSignature(signature)
+                                            .setClientExtensionResults(extMap)
                                             .setUserHandle(userHandle).build();
 
                                     result.success(msg);
@@ -338,5 +430,20 @@ public class MessageHandler implements Messages.PasskeysApi {
         }
 
         result.success(null);
+    }
+
+    ///  `hexToBase64Url`
+    public static String hexToBase64Url(String hex) {
+        int len = hex.length();
+        byte[] bytes = new byte[len / 2];
+
+        for (int i = 0; i < len; i += 2) {
+            bytes[i / 2] = (byte) Integer.parseInt(hex.substring(i, i + 2), 16);
+        }
+
+        return Base64.encodeToString(
+                bytes,
+                Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP
+        );
     }
 }

--- a/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/Messages.java
+++ b/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/Messages.java
@@ -722,6 +722,17 @@ public class Messages {
       this.transports = setterArg;
     }
 
+    /** The clientExtensionResults - PRF results */
+    private @Nullable Map<String, Object> clientExtensionResults;
+
+    public @Nullable Map<String, Object> getClientExtensionResults() {
+      return clientExtensionResults;
+    }
+
+    public void setClientExtensionResults(@Nullable Map<String, Object> setterArg) {
+      this.clientExtensionResults = setterArg;
+    }
+
     /** Constructor is non-public to enforce null safety; use Builder. */
     RegisterResponse() {}
 
@@ -762,6 +773,13 @@ public class Messages {
         return this;
       }
 
+      private @Nullable Map<String, Object> clientExtensionResults;
+
+      public @NonNull Builder setClientExtensionResults(@Nullable Map<String, Object> setterArg) {
+        this.clientExtensionResults = setterArg;
+        return this;
+      }
+
       public @NonNull RegisterResponse build() {
         RegisterResponse pigeonReturn = new RegisterResponse();
         pigeonReturn.setId(id);
@@ -769,18 +787,20 @@ public class Messages {
         pigeonReturn.setClientDataJSON(clientDataJSON);
         pigeonReturn.setAttestationObject(attestationObject);
         pigeonReturn.setTransports(transports);
+        pigeonReturn.setClientExtensionResults(clientExtensionResults);
         return pigeonReturn;
       }
     }
 
     @NonNull
     ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<Object>(5);
+      ArrayList<Object> toListResult = new ArrayList<Object>(6);
       toListResult.add(id);
       toListResult.add(rawId);
       toListResult.add(clientDataJSON);
       toListResult.add(attestationObject);
       toListResult.add(transports);
+      toListResult.add(clientExtensionResults);
       return toListResult;
     }
 
@@ -796,6 +816,8 @@ public class Messages {
       pigeonResult.setAttestationObject((String) attestationObject);
       Object transports = list.get(4);
       pigeonResult.setTransports((List<String>) transports);
+      Object clientExtensionResults = list.get(5);
+      pigeonResult.setClientExtensionResults((Map<String, Object>) clientExtensionResults);
       return pigeonResult;
     }
   }
@@ -876,6 +898,7 @@ public class Messages {
       this.signature = setterArg;
     }
 
+    /** The userHandle */
     private @NonNull String userHandle;
 
     public @NonNull String getUserHandle() {
@@ -887,6 +910,17 @@ public class Messages {
         throw new IllegalStateException("Nonnull field \"userHandle\" is null.");
       }
       this.userHandle = setterArg;
+    }
+
+    /** The clientExtensionResults - PRF results */
+    private @Nullable Map<String, Object> clientExtensionResults;
+
+    public @Nullable Map<String, Object> getClientExtensionResults() {
+      return clientExtensionResults;
+    }
+
+    public void setClientExtensionResults(@Nullable Map<String, Object> setterArg) {
+      this.clientExtensionResults = setterArg;
     }
 
     /** Constructor is non-public to enforce null safety; use Builder. */
@@ -936,6 +970,13 @@ public class Messages {
         return this;
       }
 
+      private @Nullable Map<String, Object> clientExtensionResults;
+
+      public @NonNull Builder setClientExtensionResults(@Nullable Map<String, Object> setterArg) {
+        this.clientExtensionResults = setterArg;
+        return this;
+      }
+
       public @NonNull AuthenticateResponse build() {
         AuthenticateResponse pigeonReturn = new AuthenticateResponse();
         pigeonReturn.setId(id);
@@ -944,19 +985,21 @@ public class Messages {
         pigeonReturn.setAuthenticatorData(authenticatorData);
         pigeonReturn.setSignature(signature);
         pigeonReturn.setUserHandle(userHandle);
+        pigeonReturn.setClientExtensionResults(clientExtensionResults);
         return pigeonReturn;
       }
     }
 
     @NonNull
     ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<Object>(6);
+      ArrayList<Object> toListResult = new ArrayList<Object>(7);
       toListResult.add(id);
       toListResult.add(rawId);
       toListResult.add(clientDataJSON);
       toListResult.add(authenticatorData);
       toListResult.add(signature);
       toListResult.add(userHandle);
+      toListResult.add(clientExtensionResults);
       return toListResult;
     }
 
@@ -974,6 +1017,8 @@ public class Messages {
       pigeonResult.setSignature((String) signature);
       Object userHandle = list.get(5);
       pigeonResult.setUserHandle((String) userHandle);
+      Object clientExtensionResults = list.get(6);
+      pigeonResult.setClientExtensionResults((Map<String, Object>) clientExtensionResults);
       return pigeonResult;
     }
   }
@@ -1053,9 +1098,9 @@ public class Messages {
 
     void hasPasskeySupport(@NonNull Result<Boolean> result);
 
-    void register(@NonNull String challenge, @NonNull RelyingParty relyingParty, @NonNull User user, @Nullable AuthenticatorSelection authenticatorSelection, @Nullable List<PubKeyCredParam> pubKeyCredParams, @Nullable Long timeout, @Nullable String attestation, @NonNull List<ExcludeCredential> excludeCredentials, @NonNull Result<RegisterResponse> result);
+    void register(@NonNull String challenge, @NonNull RelyingParty relyingParty, @NonNull User user, @Nullable AuthenticatorSelection authenticatorSelection, @Nullable List<PubKeyCredParam> pubKeyCredParams, @Nullable Long timeout, @Nullable String attestation, @NonNull List<ExcludeCredential> excludeCredentials, @Nullable String salt, @NonNull Result<RegisterResponse> result);
 
-    void authenticate(@NonNull String relyingPartyId, @NonNull String challenge, @Nullable Long timeout, @Nullable String userVerification, @Nullable List<AllowCredential> allowCredentials, @Nullable Boolean preferImmediatelyAvailableCredentials, @NonNull Result<AuthenticateResponse> result);
+    void authenticate(@NonNull String relyingPartyId, @NonNull String challenge, @Nullable Long timeout, @Nullable String userVerification, @Nullable List<AllowCredential> allowCredentials, @Nullable Boolean preferImmediatelyAvailableCredentials, @Nullable String salt, @NonNull Result<AuthenticateResponse> result);
 
     void cancelCurrentAuthenticatorOperation(@NonNull Result<Void> result);
 
@@ -1136,6 +1181,7 @@ public class Messages {
                 Number timeoutArg = (Number) args.get(5);
                 String attestationArg = (String) args.get(6);
                 List<ExcludeCredential> excludeCredentialsArg = (List<ExcludeCredential>) args.get(7);
+                String saltArg = (String) args.get(8);
                 Result<RegisterResponse> resultCallback =
                     new Result<RegisterResponse>() {
                       public void success(RegisterResponse result) {
@@ -1149,7 +1195,7 @@ public class Messages {
                       }
                     };
 
-                api.register(challengeArg, relyingPartyArg, userArg, authenticatorSelectionArg, pubKeyCredParamsArg, (timeoutArg == null) ? null : timeoutArg.longValue(), attestationArg, excludeCredentialsArg, resultCallback);
+                api.register(challengeArg, relyingPartyArg, userArg, authenticatorSelectionArg, pubKeyCredParamsArg, (timeoutArg == null) ? null : timeoutArg.longValue(), attestationArg, excludeCredentialsArg, saltArg, resultCallback);
               });
         } else {
           channel.setMessageHandler(null);
@@ -1170,6 +1216,7 @@ public class Messages {
                 String userVerificationArg = (String) args.get(3);
                 List<AllowCredential> allowCredentialsArg = (List<AllowCredential>) args.get(4);
                 Boolean preferImmediatelyAvailableCredentialsArg = (Boolean) args.get(5);
+                String saltArg = (String) args.get(6);
                 Result<AuthenticateResponse> resultCallback =
                     new Result<AuthenticateResponse>() {
                       public void success(AuthenticateResponse result) {
@@ -1183,7 +1230,7 @@ public class Messages {
                       }
                     };
 
-                api.authenticate(relyingPartyIdArg, challengeArg, (timeoutArg == null) ? null : timeoutArg.longValue(), userVerificationArg, allowCredentialsArg, preferImmediatelyAvailableCredentialsArg, resultCallback);
+                api.authenticate(relyingPartyIdArg, challengeArg, (timeoutArg == null) ? null : timeoutArg.longValue(), userVerificationArg, allowCredentialsArg, preferImmediatelyAvailableCredentialsArg, saltArg, resultCallback);
               });
         } else {
           channel.setMessageHandler(null);

--- a/packages/passkeys/passkeys_android/lib/messages.g.dart
+++ b/packages/passkeys/passkeys_android/lib/messages.g.dart
@@ -359,21 +359,21 @@ class _PasskeysApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128:
+      case 128: 
         return AllowCredential.decode(readValue(buffer)!);
-      case 129:
+      case 129: 
         return AuthenticateResponse.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return AuthenticatorSelection.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return ExcludeCredential.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return PubKeyCredParam.decode(readValue(buffer)!);
-      case 133:
+      case 133: 
         return RegisterResponse.decode(readValue(buffer)!);
-      case 134:
+      case 134: 
         return RelyingParty.decode(readValue(buffer)!);
-      case 135:
+      case 135: 
         return User.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -385,15 +385,18 @@ class PasskeysApi {
   /// Constructor for [PasskeysApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  PasskeysApi({BinaryMessenger? binaryMessenger}) : _binaryMessenger = binaryMessenger;
+  PasskeysApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
   final BinaryMessenger? _binaryMessenger;
 
   static const MessageCodec<Object?> codec = _PasskeysApiCodec();
 
   Future<bool> canAuthenticate() async {
-    final BasicMessageChannel<Object?> channel =
-        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_android.PasskeysApi.canAuthenticate', codec, binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.passkeys_android.PasskeysApi.canAuthenticate', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -416,9 +419,11 @@ class PasskeysApi {
   }
 
   Future<bool> hasPasskeySupport() async {
-    final BasicMessageChannel<Object?> channel =
-        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_android.PasskeysApi.hasPasskeySupport', codec, binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.passkeys_android.PasskeysApi.hasPasskeySupport', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -440,29 +445,12 @@ class PasskeysApi {
     }
   }
 
-  Future<RegisterResponse> register(
-      String arg_challenge,
-      RelyingParty arg_relyingParty,
-      User arg_user,
-      AuthenticatorSelection? arg_authenticatorSelection,
-      List<PubKeyCredParam?>? arg_pubKeyCredParams,
-      int? arg_timeout,
-      String? arg_attestation,
-      List<ExcludeCredential?> arg_excludeCredentials,
-      String? arg_salt) async {
-    final BasicMessageChannel<Object?> channel =
-        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_android.PasskeysApi.register', codec, binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(<Object?>[
-      arg_challenge,
-      arg_relyingParty,
-      arg_user,
-      arg_authenticatorSelection,
-      arg_pubKeyCredParams,
-      arg_timeout,
-      arg_attestation,
-      arg_excludeCredentials,
-      arg_salt
-    ]) as List<Object?>?;
+  Future<RegisterResponse> register(String arg_challenge, RelyingParty arg_relyingParty, User arg_user, AuthenticatorSelection? arg_authenticatorSelection, List<PubKeyCredParam?>? arg_pubKeyCredParams, int? arg_timeout, String? arg_attestation, List<ExcludeCredential?> arg_excludeCredentials, String? arg_salt) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.passkeys_android.PasskeysApi.register', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_challenge, arg_relyingParty, arg_user, arg_authenticatorSelection, arg_pubKeyCredParams, arg_timeout, arg_attestation, arg_excludeCredentials, arg_salt]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -484,20 +472,12 @@ class PasskeysApi {
     }
   }
 
-  Future<AuthenticateResponse> authenticate(String arg_relyingPartyId, String arg_challenge, int? arg_timeout, String? arg_userVerification,
-      List<AllowCredential?>? arg_allowCredentials, bool? arg_preferImmediatelyAvailableCredentials,
-      {String? arg_salt}) async {
-    final BasicMessageChannel<Object?> channel =
-        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_android.PasskeysApi.authenticate', codec, binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(<Object?>[
-      arg_relyingPartyId,
-      arg_challenge,
-      arg_timeout,
-      arg_userVerification,
-      arg_allowCredentials,
-      arg_preferImmediatelyAvailableCredentials,
-      arg_salt
-    ]) as List<Object?>?;
+  Future<AuthenticateResponse> authenticate(String arg_relyingPartyId, String arg_challenge, int? arg_timeout, String? arg_userVerification, List<AllowCredential?>? arg_allowCredentials, bool? arg_preferImmediatelyAvailableCredentials, String? arg_salt) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.passkeys_android.PasskeysApi.authenticate', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_relyingPartyId, arg_challenge, arg_timeout, arg_userVerification, arg_allowCredentials, arg_preferImmediatelyAvailableCredentials, arg_salt]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -523,7 +503,8 @@ class PasskeysApi {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.passkeys_android.PasskeysApi.cancelCurrentAuthenticatorOperation', codec,
         binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/packages/passkeys/passkeys_android/lib/messages.g.dart
+++ b/packages/passkeys/passkeys_android/lib/messages.g.dart
@@ -219,6 +219,7 @@ class RegisterResponse {
     required this.clientDataJSON,
     required this.attestationObject,
     required this.transports,
+    this.clientExtensionResults,
   });
 
   /// The ID
@@ -236,6 +237,9 @@ class RegisterResponse {
   /// The supported transports for the authenticator
   List<String?> transports;
 
+  /// The clientExtensionResults - PRF results
+  Map<String?, Object?>? clientExtensionResults;
+
   Object encode() {
     return <Object?>[
       id,
@@ -243,6 +247,7 @@ class RegisterResponse {
       clientDataJSON,
       attestationObject,
       transports,
+      clientExtensionResults,
     ];
   }
 
@@ -254,6 +259,7 @@ class RegisterResponse {
       clientDataJSON: result[2]! as String,
       attestationObject: result[3]! as String,
       transports: (result[4] as List<Object?>?)!.cast<String?>(),
+      clientExtensionResults: (result[5] as Map<Object?, Object?>?)?.cast<String?, Object?>(),
     );
   }
 }
@@ -267,6 +273,7 @@ class AuthenticateResponse {
     required this.authenticatorData,
     required this.signature,
     required this.userHandle,
+    this.clientExtensionResults,
   });
 
   /// The ID
@@ -284,7 +291,11 @@ class AuthenticateResponse {
   /// The signature
   String signature;
 
+  /// The userHandle
   String userHandle;
+
+  /// The clientExtensionResults - PRF results
+  Map<String?, Object?>? clientExtensionResults;
 
   Object encode() {
     return <Object?>[
@@ -294,6 +305,7 @@ class AuthenticateResponse {
       authenticatorData,
       signature,
       userHandle,
+      clientExtensionResults,
     ];
   }
 
@@ -306,6 +318,7 @@ class AuthenticateResponse {
       authenticatorData: result[3]! as String,
       signature: result[4]! as String,
       userHandle: result[5]! as String,
+      clientExtensionResults: (result[6] as Map<Object?, Object?>?)?.cast<String?, Object?>(),
     );
   }
 }
@@ -346,21 +359,21 @@ class _PasskeysApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128: 
+      case 128:
         return AllowCredential.decode(readValue(buffer)!);
-      case 129: 
+      case 129:
         return AuthenticateResponse.decode(readValue(buffer)!);
-      case 130: 
+      case 130:
         return AuthenticatorSelection.decode(readValue(buffer)!);
-      case 131: 
+      case 131:
         return ExcludeCredential.decode(readValue(buffer)!);
-      case 132: 
+      case 132:
         return PubKeyCredParam.decode(readValue(buffer)!);
-      case 133: 
+      case 133:
         return RegisterResponse.decode(readValue(buffer)!);
-      case 134: 
+      case 134:
         return RelyingParty.decode(readValue(buffer)!);
-      case 135: 
+      case 135:
         return User.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -372,18 +385,15 @@ class PasskeysApi {
   /// Constructor for [PasskeysApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  PasskeysApi({BinaryMessenger? binaryMessenger})
-      : _binaryMessenger = binaryMessenger;
+  PasskeysApi({BinaryMessenger? binaryMessenger}) : _binaryMessenger = binaryMessenger;
   final BinaryMessenger? _binaryMessenger;
 
   static const MessageCodec<Object?> codec = _PasskeysApiCodec();
 
   Future<bool> canAuthenticate() async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_android.PasskeysApi.canAuthenticate', codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(null) as List<Object?>?;
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_android.PasskeysApi.canAuthenticate', codec, binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -406,11 +416,9 @@ class PasskeysApi {
   }
 
   Future<bool> hasPasskeySupport() async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_android.PasskeysApi.hasPasskeySupport', codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(null) as List<Object?>?;
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_android.PasskeysApi.hasPasskeySupport', codec, binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -432,12 +440,29 @@ class PasskeysApi {
     }
   }
 
-  Future<RegisterResponse> register(String arg_challenge, RelyingParty arg_relyingParty, User arg_user, AuthenticatorSelection? arg_authenticatorSelection, List<PubKeyCredParam?>? arg_pubKeyCredParams, int? arg_timeout, String? arg_attestation, List<ExcludeCredential?> arg_excludeCredentials) async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_android.PasskeysApi.register', codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_challenge, arg_relyingParty, arg_user, arg_authenticatorSelection, arg_pubKeyCredParams, arg_timeout, arg_attestation, arg_excludeCredentials]) as List<Object?>?;
+  Future<RegisterResponse> register(
+      String arg_challenge,
+      RelyingParty arg_relyingParty,
+      User arg_user,
+      AuthenticatorSelection? arg_authenticatorSelection,
+      List<PubKeyCredParam?>? arg_pubKeyCredParams,
+      int? arg_timeout,
+      String? arg_attestation,
+      List<ExcludeCredential?> arg_excludeCredentials,
+      String? arg_salt) async {
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_android.PasskeysApi.register', codec, binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(<Object?>[
+      arg_challenge,
+      arg_relyingParty,
+      arg_user,
+      arg_authenticatorSelection,
+      arg_pubKeyCredParams,
+      arg_timeout,
+      arg_attestation,
+      arg_excludeCredentials,
+      arg_salt
+    ]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -459,12 +484,20 @@ class PasskeysApi {
     }
   }
 
-  Future<AuthenticateResponse> authenticate(String arg_relyingPartyId, String arg_challenge, int? arg_timeout, String? arg_userVerification, List<AllowCredential?>? arg_allowCredentials, bool? arg_preferImmediatelyAvailableCredentials) async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_android.PasskeysApi.authenticate', codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_relyingPartyId, arg_challenge, arg_timeout, arg_userVerification, arg_allowCredentials, arg_preferImmediatelyAvailableCredentials]) as List<Object?>?;
+  Future<AuthenticateResponse> authenticate(String arg_relyingPartyId, String arg_challenge, int? arg_timeout, String? arg_userVerification,
+      List<AllowCredential?>? arg_allowCredentials, bool? arg_preferImmediatelyAvailableCredentials,
+      {String? arg_salt}) async {
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_android.PasskeysApi.authenticate', codec, binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(<Object?>[
+      arg_relyingPartyId,
+      arg_challenge,
+      arg_timeout,
+      arg_userVerification,
+      arg_allowCredentials,
+      arg_preferImmediatelyAvailableCredentials,
+      arg_salt
+    ]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -490,8 +523,7 @@ class PasskeysApi {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.passkeys_android.PasskeysApi.cancelCurrentAuthenticatorOperation', codec,
         binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(null) as List<Object?>?;
+    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/packages/passkeys/passkeys_android/lib/passkeys_android.dart
+++ b/packages/passkeys/passkeys_android/lib/passkeys_android.dart
@@ -16,7 +16,7 @@ class PasskeysAndroid extends PasskeysPlatform {
   final PasskeysApi _api;
 
   @override
-  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt}) async {
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, String? salt) async {
     final r = await _api.authenticate(
       request.relyingPartyId,
       request.challenge,
@@ -30,7 +30,7 @@ class PasskeysAndroid extends PasskeysPlatform {
         );
       }).toList(),
       request.preferImmediatelyAvailableCredentials,
-      arg_salt: salt,
+      salt,
     );
 
     return AuthenticateResponseType(
@@ -54,7 +54,7 @@ class PasskeysAndroid extends PasskeysPlatform {
   }
 
   @override
-  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async {
+  Future<RegisterResponseType> register(RegisterRequestType request, String? salt) async {
     final userArg = User(
       displayName: request.user.displayName,
       name: request.user.name,

--- a/packages/passkeys/passkeys_android/lib/passkeys_android.dart
+++ b/packages/passkeys/passkeys_android/lib/passkeys_android.dart
@@ -16,9 +16,7 @@ class PasskeysAndroid extends PasskeysPlatform {
   final PasskeysApi _api;
 
   @override
-  Future<AuthenticateResponseType> authenticate(
-    AuthenticateRequestType request,
-  ) async {
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt}) async {
     final r = await _api.authenticate(
       request.relyingPartyId,
       request.challenge,
@@ -28,10 +26,11 @@ class PasskeysAndroid extends PasskeysPlatform {
         return AllowCredential(
           id: e.id,
           type: e.type,
-          transports: e.transports,
+          transports: e.transports ?? [],
         );
       }).toList(),
       request.preferImmediatelyAvailableCredentials,
+      arg_salt: salt,
     );
 
     return AuthenticateResponseType(
@@ -40,7 +39,8 @@ class PasskeysAndroid extends PasskeysPlatform {
         clientDataJSON: r.clientDataJSON,
         authenticatorData: r.authenticatorData,
         signature: r.signature,
-        userHandle: r.userHandle);
+        userHandle: r.userHandle,
+        clientExtensionResults: r.clientExtensionResults);
   }
 
   @override
@@ -54,7 +54,7 @@ class PasskeysAndroid extends PasskeysPlatform {
   }
 
   @override
-  Future<RegisterResponseType> register(RegisterRequestType request) async {
+  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async {
     final userArg = User(
       displayName: request.user.displayName,
       name: request.user.name,
@@ -85,14 +85,11 @@ class PasskeysAndroid extends PasskeysPlatform {
         relyingPartyArg,
         userArg,
         authSelection,
-        request.pubKeyCredParams
-            ?.map((e) => PubKeyCredParam(alg: e.alg, type: e.type))
-            .toList(),
+        request.pubKeyCredParams?.map((e) => PubKeyCredParam(alg: e.alg, type: e.type)).toList(),
         request.timeout,
         request.attestation,
-        request.excludeCredentials
-            .map((e) => ExcludeCredential(id: e.id, type: e.type))
-            .toList());
+        request.excludeCredentials.map((e) => ExcludeCredential(id: e.id, type: e.type)).toList(),
+        salt);
 
     return RegisterResponseType(
       id: r.id,
@@ -100,6 +97,7 @@ class PasskeysAndroid extends PasskeysPlatform {
       clientDataJSON: r.clientDataJSON,
       attestationObject: r.attestationObject,
       transports: r.transports.whereType<String>().toList(),
+      clientExtensionResults: r.clientExtensionResults,
     );
   }
 
@@ -112,15 +110,13 @@ class PasskeysAndroid extends PasskeysPlatform {
   // In case of android we link passkey support to the availability of the biometric authentication
   @override
   Future<AvailabilityTypeAndroid> getAvailability() async {
-    final isUserVerifyingPlatformAuthenticatorAvailable =
-        await canAuthenticate();
+    final isUserVerifyingPlatformAuthenticatorAvailable = await canAuthenticate();
 
     final hasPasskeySupport = await _api.hasPasskeySupport();
 
     return AvailabilityTypeAndroid(
       hasPasskeySupport: hasPasskeySupport,
-      isUserVerifyingPlatformAuthenticatorAvailable:
-          isUserVerifyingPlatformAuthenticatorAvailable,
+      isUserVerifyingPlatformAuthenticatorAvailable: isUserVerifyingPlatformAuthenticatorAvailable,
       isNative: true,
     );
   }

--- a/packages/passkeys/passkeys_android/pigeons/messages.dart
+++ b/packages/passkeys/passkeys_android/pigeons/messages.dart
@@ -189,9 +189,9 @@ abstract class PasskeysApi {
     int? timeout,
     String? userVerification,
     List<AllowCredential>? allowCredentials,
-    bool? preferImmediatelyAvailableCredentials, {
+    bool? preferImmediatelyAvailableCredentials,
     String? salt,
-  });
+  );
 
   @async
   void cancelCurrentAuthenticatorOperation();

--- a/packages/passkeys/passkeys_android/pigeons/messages.dart
+++ b/packages/passkeys/passkeys_android/pigeons/messages.dart
@@ -80,8 +80,7 @@ class ExcludeCredential {
 /// Represents an authenticator selection
 class AuthenticatorSelection {
   /// Constructor
-  const AuthenticatorSelection(this.authenticatorAttachment,
-      this.requireResidentKey, this.residentKey, this.userVerification);
+  const AuthenticatorSelection(this.authenticatorAttachment, this.requireResidentKey, this.residentKey, this.userVerification);
 
   /// The authenticator attachment
   final String? authenticatorAttachment;
@@ -105,6 +104,7 @@ class RegisterResponse {
     required this.clientDataJSON,
     required this.attestationObject,
     required this.transports,
+    this.clientExtensionResults = const {},
   });
 
   /// The ID
@@ -121,6 +121,9 @@ class RegisterResponse {
 
   /// The supported transports for the authenticator
   final List<String?> transports;
+
+  /// The clientExtensionResults - PRF results
+  final Map<String?, Object?>? clientExtensionResults;
 }
 
 /// Represents an authenticate response
@@ -133,6 +136,7 @@ class AuthenticateResponse {
     required this.authenticatorData,
     required this.signature,
     required this.userHandle,
+    this.clientExtensionResults = const {},
   });
 
   /// The ID
@@ -150,7 +154,11 @@ class AuthenticateResponse {
   /// The signature
   final String signature;
 
+  /// The userHandle
   final String userHandle;
+
+  /// The clientExtensionResults - PRF results
+  final Map<String?, Object?>? clientExtensionResults;
 }
 
 @HostApi()
@@ -171,16 +179,19 @@ abstract class PasskeysApi {
     int? timeout,
     String? attestation,
     List<ExcludeCredential> excludeCredentials,
+    String? salt,
   );
 
   @async
   AuthenticateResponse authenticate(
-      String relyingPartyId,
-      String challenge,
-      int? timeout,
-      String? userVerification,
-      List<AllowCredential>? allowCredentials,
-      bool? preferImmediatelyAvailableCredentials);
+    String relyingPartyId,
+    String challenge,
+    int? timeout,
+    String? userVerification,
+    List<AllowCredential>? allowCredentials,
+    bool? preferImmediatelyAvailableCredentials, {
+    String? salt,
+  });
 
   @async
   void cancelCurrentAuthenticatorOperation();

--- a/packages/passkeys/passkeys_android/pubspec.yaml
+++ b/packages/passkeys/passkeys_android/pubspec.yaml
@@ -3,6 +3,7 @@ description: Android implementation of the Corbado passkeys plugin. Manages the 
 homepage: https://docs.corbado.com/overview/welcome
 repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passkeys/passkeys_android
 version: 2.11.0
+resolution: workspace
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
@@ -303,6 +303,14 @@ public extension Data {
         return fromBase64(base64String)
     }
 
+    func toBase64URL() -> String {
+        var result = self.base64EncodedString()
+        result = result.replacingOccurrences(of: "+", with: "-")
+        result = result.replacingOccurrences(of: "/", with: "_")
+        result = result.replacingOccurrences(of: "=", with: "")
+        return result
+    }
+
     private static func base64UrlToBase64(base64Url: String) -> String {
         return base64Url.replacingOccurrences(of: "-", with: "+")
                          .replacingOccurrences(of: "_", with: "/")

--- a/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
@@ -53,6 +53,7 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
         canBeSecurityKey: Bool = true,
         residentKeyPreference: String?,
         attestationPreference: String?,
+        salt: String?,
         completion: @escaping (Result<RegisterResponse, Error>) -> Void
     ) {
         guard (try? canAuthenticate()) == true else {
@@ -86,6 +87,15 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
             if #available(iOS 17.4, *) {
                 let excluded = parseCredentials(credentials: excludeCredentials)
                 platformRequest.excludedCredentials = excluded
+            }
+
+            // PRF
+            if #available(iOS 18.0, *) {
+            guard let saltB64Url = salt, let saltB64Url = Data.fromBase64Url(saltB64Url) else {
+                return
+            }
+            let values = ASAuthorizationPublicKeyCredentialPRFAssertionInput.InputValues(saltInput1: saltB64Url)
+                platformRequest.prf = ASAuthorizationPublicKeyCredentialPRFRegistrationInput.inputValues(values)
             }
             
             requests.append(platformRequest)

--- a/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
@@ -91,10 +91,10 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
 
             // PRF
             if #available(iOS 18.0, *) {
-            guard let saltB64Url = salt, let saltB64Url = Data.fromBase64Url(saltB64Url) else {
+                guard let salt = salt, let saltData = Data(hex: salt) else {
                 return
             }
-            let values = ASAuthorizationPublicKeyCredentialPRFAssertionInput.InputValues(saltInput1: saltB64Url)
+            let values = ASAuthorizationPublicKeyCredentialPRFAssertionInput.InputValues(saltInput1: saltData)
                 platformRequest.prf = ASAuthorizationPublicKeyCredentialPRFRegistrationInput.inputValues(values)
             }
             
@@ -185,8 +185,8 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
         
         // PRF
         if #available(iOS 18.0, *) {
-        guard let saltB64Url = salt, let saltB64Url = Data.fromBase64Url(saltB64Url) else { return }
-        let values = ASAuthorizationPublicKeyCredentialPRFAssertionInput.InputValues(saltInput1: saltB64Url)
+            guard let salt = salt, let saltData = Data(hex: salt) else { return }
+        let values = ASAuthorizationPublicKeyCredentialPRFAssertionInput.InputValues(saltInput1: saltData)
             platformRequest.prf = ASAuthorizationPublicKeyCredentialPRFAssertionInput.inputValues(values)
         }
         
@@ -326,4 +326,24 @@ extension Data {
         result = result.replacingOccurrences(of: "=", with: "")
         return result
     }
+    
+    init?(hex: String) {
+        let hex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard hex.count % 2 == 0 else { return nil }
+
+        var data = Data(capacity: hex.count / 2)
+        var index = hex.startIndex
+
+        while index < hex.endIndex {
+            let nextIndex = hex.index(index, offsetBy: 2)
+            let byteString = hex[index..<nextIndex]
+            guard let byte = UInt8(byteString, radix: 16) else { return nil }
+            data.append(byte)
+            index = nextIndex
+        }
+
+        self = data
+    }
 }
+
+

--- a/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
@@ -307,25 +307,7 @@ public extension Data {
         return base64Url.replacingOccurrences(of: "-", with: "+")
                          .replacingOccurrences(of: "_", with: "/")
     }
-}
-
-public extension String {
-    static func fromBase64(_ encoded: String) -> String? {
-        if let data = Data.fromBase64(encoded) {
-            return String(data: data, encoding: .utf8)
-        }
-        return nil
-    }
-}
-
-extension Data {
-    func toBase64URL() -> String {
-        var result = self.base64EncodedString()
-        result = result.replacingOccurrences(of: "+", with: "-")
-        result = result.replacingOccurrences(of: "/", with: "_")
-        result = result.replacingOccurrences(of: "=", with: "")
-        return result
-    }
+    
     
     init?(hex: String) {
         let hex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -346,4 +328,12 @@ extension Data {
     }
 }
 
+public extension String {
+    static func fromBase64(_ encoded: String) -> String? {
+        if let data = Data.fromBase64(encoded) {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
+}
 

--- a/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/Classes/PasskeysPlugin.swift
@@ -309,6 +309,7 @@ public extension Data {
     }
     
     
+    /// init    - https://stackoverflow.com/questions/26501276/converting-hex-string-to-nsdata-in-swift
     init?(hex: String) {
         let hex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         guard hex.count % 2 == 0 else { return nil }

--- a/packages/passkeys/passkeys_darwin/darwin/Classes/RegisterController.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/Classes/RegisterController.swift
@@ -37,13 +37,22 @@ class RegisterController: NSObject, ASAuthorizationControllerDelegate, ASAuthori
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         switch authorization.credential {
         case let credentialRegistration as ASAuthorizationPlatformPublicKeyCredentialRegistration:
+            var prfString: String? = nil
+            if #available(iOS 18.0, *),
+               let prf = credentialRegistration.prf,
+               let prfBytes = prf.first?.withUnsafeBytes({ Data($0) }) {
+                prfString = prfBytes.base64EncodedString()
+            }
+            
             let response = RegisterResponse(
+                prf: prfString,
                 id: credentialRegistration.credentialID.toBase64URL(),
                 rawId: credentialRegistration.credentialID.toBase64URL(),
                 clientDataJSON: credentialRegistration.rawClientDataJSON.toBase64URL(),
                 attestationObject: credentialRegistration.rawAttestationObject!.toBase64URL(),
                 transports: []
             )
+            
             completion?(.success(response))
             break
         case let securityKeyRegistration as ASAuthorizationSecurityKeyPublicKeyCredentialRegistration:

--- a/packages/passkeys/passkeys_darwin/darwin/Classes/RegisterController.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/Classes/RegisterController.swift
@@ -45,7 +45,6 @@ class RegisterController: NSObject, ASAuthorizationControllerDelegate, ASAuthori
             }
             
             let response = RegisterResponse(
-                prf: prfString,
                 id: credentialRegistration.credentialID.toBase64URL(),
                 rawId: credentialRegistration.credentialID.toBase64URL(),
                 clientDataJSON: credentialRegistration.rawClientDataJSON.toBase64URL(),

--- a/packages/passkeys/passkeys_darwin/darwin/Classes/messages.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/Classes/messages.swift
@@ -125,6 +125,8 @@ struct User {
 ///
 /// Generated class from Pigeon that represents data sent in messages.
 struct RegisterResponse {
+  /// The PRF
+  var prf: String? = nil
   /// The ID
   var id: String
   /// The raw ID
@@ -137,13 +139,15 @@ struct RegisterResponse {
   var transports: [String?]
 
   static func fromList(_ list: [Any?]) -> RegisterResponse? {
-    let id = list[0] as! String
-    let rawId = list[1] as! String
-    let clientDataJSON = list[2] as! String
-    let attestationObject = list[3] as! String
-    let transports = list[4] as! [String?]
+    let prf: String? = nilOrValue(list[0])
+    let id = list[1] as! String
+    let rawId = list[2] as! String
+    let clientDataJSON = list[3] as! String
+    let attestationObject = list[4] as! String
+    let transports = list[5] as! [String?]
 
     return RegisterResponse(
+      prf: prf,
       id: id,
       rawId: rawId,
       clientDataJSON: clientDataJSON,
@@ -153,6 +157,7 @@ struct RegisterResponse {
   }
   func toList() -> [Any?] {
     return [
+      prf,
       id,
       rawId,
       clientDataJSON,
@@ -267,7 +272,7 @@ class PasskeysApiCodec: FlutterStandardMessageCodec {
 protocol PasskeysApi {
   func canAuthenticate() throws -> Bool
   func hasBiometrics() throws -> Bool
-  func register(challenge: String, relyingParty: RelyingParty, user: User, excludeCredentials: [CredentialType], pubKeyCredValues: [Int64], canBePlatformAuthenticator: Bool, canBeSecurityKey: Bool, residentKeyPreference: String?, attestationPreference: String?, completion: @escaping (Result<RegisterResponse, Error>) -> Void)
+  func register(challenge: String, relyingParty: RelyingParty, user: User, excludeCredentials: [CredentialType], pubKeyCredValues: [Int64], canBePlatformAuthenticator: Bool, canBeSecurityKey: Bool, residentKeyPreference: String?, attestationPreference: String?, salt: String?, completion: @escaping (Result<RegisterResponse, Error>) -> Void)
   func authenticate(relyingPartyId: String, challenge: String, conditionalUI: Bool, allowedCredentials: [CredentialType], preferImmediatelyAvailableCredentials: Bool, completion: @escaping (Result<AuthenticateResponse, Error>) -> Void)
   func cancelCurrentAuthenticatorOperation(completion: @escaping (Result<Void, Error>) -> Void)
 }
@@ -317,7 +322,8 @@ class PasskeysApiSetup {
         let canBeSecurityKeyArg = args[6] as! Bool
         let residentKeyPreferenceArg: String? = nilOrValue(args[7])
         let attestationPreferenceArg: String? = nilOrValue(args[8])
-        api.register(challenge: challengeArg, relyingParty: relyingPartyArg, user: userArg, excludeCredentials: excludeCredentialsArg, pubKeyCredValues: pubKeyCredValuesArg, canBePlatformAuthenticator: canBePlatformAuthenticatorArg, canBeSecurityKey: canBeSecurityKeyArg, residentKeyPreference: residentKeyPreferenceArg, attestationPreference: attestationPreferenceArg) { result in
+        let saltArg: String? = nilOrValue(args[9])
+        api.register(challenge: challengeArg, relyingParty: relyingPartyArg, user: userArg, excludeCredentials: excludeCredentialsArg, pubKeyCredValues: pubKeyCredValuesArg, canBePlatformAuthenticator: canBePlatformAuthenticatorArg, canBeSecurityKey: canBeSecurityKeyArg, residentKeyPreference: residentKeyPreferenceArg, attestationPreference: attestationPreferenceArg, salt: saltArg) { result in
           switch result {
             case .success(let res):
               reply(wrapResult(res))

--- a/packages/passkeys/passkeys_darwin/darwin/Classes/messages.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/Classes/messages.swift
@@ -125,8 +125,6 @@ struct User {
 ///
 /// Generated class from Pigeon that represents data sent in messages.
 struct RegisterResponse {
-  /// The PRF
-  var prf: String? = nil
   /// The ID
   var id: String
   /// The raw ID
@@ -149,7 +147,6 @@ struct RegisterResponse {
     let clientExtensionResults: [String?: Any?]? = nilOrValue(list[5])
 
     return RegisterResponse(
-      prf: prf,
       id: id,
       rawId: rawId,
       clientDataJSON: clientDataJSON,
@@ -160,7 +157,6 @@ struct RegisterResponse {
   }
   func toList() -> [Any?] {
     return [
-      prf,
       id,
       rawId,
       clientDataJSON,

--- a/packages/passkeys/passkeys_darwin/lib/messages.g.dart
+++ b/packages/passkeys/passkeys_darwin/lib/messages.g.dart
@@ -104,7 +104,6 @@ class User {
 /// Represents a register response
 class RegisterResponse {
   RegisterResponse({
-    this.prf,
     required this.id,
     required this.rawId,
     required this.clientDataJSON,
@@ -112,9 +111,6 @@ class RegisterResponse {
     required this.transports,
     this.clientExtensionResults,
   });
-
-  /// The PRF
-  String? prf;
 
   /// The ID
   String id;
@@ -136,7 +132,6 @@ class RegisterResponse {
 
   Object encode() {
     return <Object?>[
-      prf,
       id,
       rawId,
       clientDataJSON,
@@ -244,15 +239,15 @@ class _PasskeysApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128:
+      case 128: 
         return AuthenticateResponse.decode(readValue(buffer)!);
-      case 129:
+      case 129: 
         return CredentialType.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return RegisterResponse.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return RelyingParty.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return User.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -264,15 +259,18 @@ class PasskeysApi {
   /// Constructor for [PasskeysApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  PasskeysApi({BinaryMessenger? binaryMessenger}) : _binaryMessenger = binaryMessenger;
+  PasskeysApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
   final BinaryMessenger? _binaryMessenger;
 
   static const MessageCodec<Object?> codec = _PasskeysApiCodec();
 
   Future<bool> canAuthenticate() async {
-    final BasicMessageChannel<Object?> channel =
-        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_darwin.PasskeysApi.canAuthenticate', codec, binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.canAuthenticate', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -295,9 +293,11 @@ class PasskeysApi {
   }
 
   Future<bool> hasBiometrics() async {
-    final BasicMessageChannel<Object?> channel =
-        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_darwin.PasskeysApi.hasBiometrics', codec, binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.hasBiometrics', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -319,31 +319,12 @@ class PasskeysApi {
     }
   }
 
-  Future<RegisterResponse> register(
-      String arg_challenge,
-      RelyingParty arg_relyingParty,
-      User arg_user,
-      List<CredentialType?> arg_excludeCredentials,
-      List<int?> arg_pubKeyCredValues,
-      bool arg_canBePlatformAuthenticator,
-      bool arg_canBeSecurityKey,
-      String? arg_residentKeyPreference,
-      String? arg_attestationPreference,
-      String? arg_salt) async {
-    final BasicMessageChannel<Object?> channel =
-        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_darwin.PasskeysApi.register', codec, binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(<Object?>[
-      arg_challenge,
-      arg_relyingParty,
-      arg_user,
-      arg_excludeCredentials,
-      arg_pubKeyCredValues,
-      arg_canBePlatformAuthenticator,
-      arg_canBeSecurityKey,
-      arg_residentKeyPreference,
-      arg_attestationPreference,
-      arg_salt
-    ]) as List<Object?>?;
+  Future<RegisterResponse> register(String arg_challenge, RelyingParty arg_relyingParty, User arg_user, List<CredentialType?> arg_excludeCredentials, List<int?> arg_pubKeyCredValues, bool arg_canBePlatformAuthenticator, bool arg_canBeSecurityKey, String? arg_residentKeyPreference, String? arg_attestationPreference, String? arg_salt) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.register', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_challenge, arg_relyingParty, arg_user, arg_excludeCredentials, arg_pubKeyCredValues, arg_canBePlatformAuthenticator, arg_canBeSecurityKey, arg_residentKeyPreference, arg_attestationPreference, arg_salt]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -365,13 +346,12 @@ class PasskeysApi {
     }
   }
 
-  Future<AuthenticateResponse> authenticate(String arg_relyingPartyId, String arg_challenge, bool arg_conditionalUI,
-      List<CredentialType?> arg_allowedCredentials, bool arg_preferImmediatelyAvailableCredentials, String? arg_salt) async {
-    final BasicMessageChannel<Object?> channel =
-        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_darwin.PasskeysApi.authenticate', codec, binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel
-            .send(<Object?>[arg_relyingPartyId, arg_challenge, arg_conditionalUI, arg_allowedCredentials, arg_preferImmediatelyAvailableCredentials, arg_salt])
-        as List<Object?>?;
+  Future<AuthenticateResponse> authenticate(String arg_relyingPartyId, String arg_challenge, bool arg_conditionalUI, List<CredentialType?> arg_allowedCredentials, bool arg_preferImmediatelyAvailableCredentials, String? arg_salt) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.authenticate', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_relyingPartyId, arg_challenge, arg_conditionalUI, arg_allowedCredentials, arg_preferImmediatelyAvailableCredentials, arg_salt]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -397,7 +377,8 @@ class PasskeysApi {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.cancelCurrentAuthenticatorOperation', codec,
         binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/packages/passkeys/passkeys_darwin/lib/messages.g.dart
+++ b/packages/passkeys/passkeys_darwin/lib/messages.g.dart
@@ -104,12 +104,16 @@ class User {
 /// Represents a register response
 class RegisterResponse {
   RegisterResponse({
+    this.prf,
     required this.id,
     required this.rawId,
     required this.clientDataJSON,
     required this.attestationObject,
     required this.transports,
   });
+
+  /// The PRF
+  String? prf;
 
   /// The ID
   String id;
@@ -128,6 +132,7 @@ class RegisterResponse {
 
   Object encode() {
     return <Object?>[
+      prf,
       id,
       rawId,
       clientDataJSON,
@@ -139,11 +144,12 @@ class RegisterResponse {
   static RegisterResponse decode(Object result) {
     result as List<Object?>;
     return RegisterResponse(
-      id: result[0]! as String,
-      rawId: result[1]! as String,
-      clientDataJSON: result[2]! as String,
-      attestationObject: result[3]! as String,
-      transports: (result[4] as List<Object?>?)!.cast<String?>(),
+      prf: result[0] as String?,
+      id: result[1]! as String,
+      rawId: result[2]! as String,
+      clientDataJSON: result[3]! as String,
+      attestationObject: result[4]! as String,
+      transports: (result[5] as List<Object?>?)!.cast<String?>(),
     );
   }
 }
@@ -307,12 +313,12 @@ class PasskeysApi {
     }
   }
 
-  Future<RegisterResponse> register(String arg_challenge, RelyingParty arg_relyingParty, User arg_user, List<CredentialType?> arg_excludeCredentials, List<int?> arg_pubKeyCredValues, bool arg_canBePlatformAuthenticator, bool arg_canBeSecurityKey, String? arg_residentKeyPreference, String? arg_attestationPreference) async {
+  Future<RegisterResponse> register(String arg_challenge, RelyingParty arg_relyingParty, User arg_user, List<CredentialType?> arg_excludeCredentials, List<int?> arg_pubKeyCredValues, bool arg_canBePlatformAuthenticator, bool arg_canBeSecurityKey, String? arg_residentKeyPreference, String? arg_attestationPreference, String? arg_salt) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.register', codec,
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_challenge, arg_relyingParty, arg_user, arg_excludeCredentials, arg_pubKeyCredValues, arg_canBePlatformAuthenticator, arg_canBeSecurityKey, arg_residentKeyPreference, arg_attestationPreference]) as List<Object?>?;
+        await channel.send(<Object?>[arg_challenge, arg_relyingParty, arg_user, arg_excludeCredentials, arg_pubKeyCredValues, arg_canBePlatformAuthenticator, arg_canBeSecurityKey, arg_residentKeyPreference, arg_attestationPreference, arg_salt]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/packages/passkeys/passkeys_darwin/lib/messages.g.dart
+++ b/packages/passkeys/passkeys_darwin/lib/messages.g.dart
@@ -109,6 +109,7 @@ class RegisterResponse {
     required this.clientDataJSON,
     required this.attestationObject,
     required this.transports,
+    this.clientExtensionResults,
   });
 
   /// The ID
@@ -126,6 +127,9 @@ class RegisterResponse {
   /// The supported transports for the authenticator
   List<String?> transports;
 
+  /// The clientExtensionResults - PRF results
+  Map<String?, Object?>? clientExtensionResults;
+
   Object encode() {
     return <Object?>[
       id,
@@ -133,6 +137,7 @@ class RegisterResponse {
       clientDataJSON,
       attestationObject,
       transports,
+      clientExtensionResults,
     ];
   }
 
@@ -144,6 +149,7 @@ class RegisterResponse {
       clientDataJSON: result[2]! as String,
       attestationObject: result[3]! as String,
       transports: (result[4] as List<Object?>?)!.cast<String?>(),
+      clientExtensionResults: (result[5] as Map<Object?, Object?>?)?.cast<String?, Object?>(),
     );
   }
 }
@@ -157,6 +163,7 @@ class AuthenticateResponse {
     required this.authenticatorData,
     required this.signature,
     this.userHandle,
+    this.clientExtensionResults,
   });
 
   /// The ID
@@ -176,6 +183,9 @@ class AuthenticateResponse {
 
   String? userHandle;
 
+  /// The clientExtensionResults - PRF results
+  Map<String?, Object?>? clientExtensionResults;
+
   Object encode() {
     return <Object?>[
       id,
@@ -184,6 +194,7 @@ class AuthenticateResponse {
       authenticatorData,
       signature,
       userHandle,
+      clientExtensionResults,
     ];
   }
 
@@ -196,6 +207,7 @@ class AuthenticateResponse {
       authenticatorData: result[3]! as String,
       signature: result[4]! as String,
       userHandle: result[5] as String?,
+      clientExtensionResults: (result[6] as Map<Object?, Object?>?)?.cast<String?, Object?>(),
     );
   }
 }
@@ -227,15 +239,15 @@ class _PasskeysApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128: 
+      case 128:
         return AuthenticateResponse.decode(readValue(buffer)!);
-      case 129: 
+      case 129:
         return CredentialType.decode(readValue(buffer)!);
-      case 130: 
+      case 130:
         return RegisterResponse.decode(readValue(buffer)!);
-      case 131: 
+      case 131:
         return RelyingParty.decode(readValue(buffer)!);
-      case 132: 
+      case 132:
         return User.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -247,18 +259,15 @@ class PasskeysApi {
   /// Constructor for [PasskeysApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  PasskeysApi({BinaryMessenger? binaryMessenger})
-      : _binaryMessenger = binaryMessenger;
+  PasskeysApi({BinaryMessenger? binaryMessenger}) : _binaryMessenger = binaryMessenger;
   final BinaryMessenger? _binaryMessenger;
 
   static const MessageCodec<Object?> codec = _PasskeysApiCodec();
 
   Future<bool> canAuthenticate() async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.canAuthenticate', codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(null) as List<Object?>?;
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_darwin.PasskeysApi.canAuthenticate', codec, binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -281,11 +290,9 @@ class PasskeysApi {
   }
 
   Future<bool> hasBiometrics() async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.hasBiometrics', codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(null) as List<Object?>?;
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_darwin.PasskeysApi.hasBiometrics', codec, binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -307,12 +314,31 @@ class PasskeysApi {
     }
   }
 
-  Future<RegisterResponse> register(String arg_challenge, RelyingParty arg_relyingParty, User arg_user, List<CredentialType?> arg_excludeCredentials, List<int?> arg_pubKeyCredValues, bool arg_canBePlatformAuthenticator, bool arg_canBeSecurityKey, String? arg_residentKeyPreference, String? arg_attestationPreference) async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.register', codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_challenge, arg_relyingParty, arg_user, arg_excludeCredentials, arg_pubKeyCredValues, arg_canBePlatformAuthenticator, arg_canBeSecurityKey, arg_residentKeyPreference, arg_attestationPreference]) as List<Object?>?;
+  Future<RegisterResponse> register(
+      String arg_challenge,
+      RelyingParty arg_relyingParty,
+      User arg_user,
+      List<CredentialType?> arg_excludeCredentials,
+      List<int?> arg_pubKeyCredValues,
+      bool arg_canBePlatformAuthenticator,
+      bool arg_canBeSecurityKey,
+      String? arg_residentKeyPreference,
+      String? arg_attestationPreference,
+      String? arg_salt) async {
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_darwin.PasskeysApi.register', codec, binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(<Object?>[
+      arg_challenge,
+      arg_relyingParty,
+      arg_user,
+      arg_excludeCredentials,
+      arg_pubKeyCredValues,
+      arg_canBePlatformAuthenticator,
+      arg_canBeSecurityKey,
+      arg_residentKeyPreference,
+      arg_attestationPreference,
+      arg_salt
+    ]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -334,12 +360,13 @@ class PasskeysApi {
     }
   }
 
-  Future<AuthenticateResponse> authenticate(String arg_relyingPartyId, String arg_challenge, bool arg_conditionalUI, List<CredentialType?> arg_allowedCredentials, bool arg_preferImmediatelyAvailableCredentials) async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.authenticate', codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_relyingPartyId, arg_challenge, arg_conditionalUI, arg_allowedCredentials, arg_preferImmediatelyAvailableCredentials]) as List<Object?>?;
+  Future<AuthenticateResponse> authenticate(String arg_relyingPartyId, String arg_challenge, bool arg_conditionalUI,
+      List<CredentialType?> arg_allowedCredentials, bool arg_preferImmediatelyAvailableCredentials, String? arg_salt) async {
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_darwin.PasskeysApi.authenticate', codec, binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel
+            .send(<Object?>[arg_relyingPartyId, arg_challenge, arg_conditionalUI, arg_allowedCredentials, arg_preferImmediatelyAvailableCredentials, arg_salt])
+        as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -365,8 +392,7 @@ class PasskeysApi {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.cancelCurrentAuthenticatorOperation', codec,
         binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(null) as List<Object?>?;
+    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/packages/passkeys/passkeys_darwin/lib/passkeys_darwin.dart
+++ b/packages/passkeys/passkeys_darwin/lib/passkeys_darwin.dart
@@ -21,7 +21,7 @@ class PasskeysDarwin extends PasskeysPlatform {
   Future<bool> canAuthenticate() async => _api.canAuthenticate();
 
   @override
-  Future<RegisterResponseType> register(RegisterRequestType request) async {
+  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async {
     final userArg = User(name: request.user.name, id: request.user.id);
     final relyingPartyArg = RelyingParty(
       name: request.relyingParty.name,
@@ -32,21 +32,17 @@ class PasskeysDarwin extends PasskeysPlatform {
       request.challenge,
       relyingPartyArg,
       userArg,
-      request.excludeCredentials
-          .map((e) =>
-              CredentialType(type: e.type, id: e.id, transports: e.transports))
-          .toList(),
+      request.excludeCredentials.map((e) => CredentialType(type: e.type, id: e.id, transports: e.transports ?? [])).toList(),
       request.pubKeyCredParams?.map((e) => e.alg).toList() ?? [],
-      request.authSelectionType == null ||
-          request.authSelectionType!.authenticatorAttachment !=
-              'cross-platform',
-      request.authSelectionType == null ||
-          request.authSelectionType!.authenticatorAttachment != 'platform',
+      request.authSelectionType == null || request.authSelectionType!.authenticatorAttachment != 'cross-platform',
+      request.authSelectionType == null || request.authSelectionType!.authenticatorAttachment != 'platform',
       request.authSelectionType?.residentKey,
       request.attestation,
+      salt,
     );
 
     return RegisterResponseType(
+      clientExtensionResults: r.clientExtensionResults,
       id: r.id,
       rawId: r.rawId,
       clientDataJSON: r.clientDataJSON,
@@ -56,9 +52,7 @@ class PasskeysDarwin extends PasskeysPlatform {
   }
 
   @override
-  Future<AuthenticateResponseType> authenticate(
-    AuthenticateRequestType request,
-  ) async {
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt}) async {
     var conditionalUI = false;
     if (request.mediation == MediationType.Conditional) {
       conditionalUI = true;
@@ -68,12 +62,9 @@ class PasskeysDarwin extends PasskeysPlatform {
       request.relyingPartyId,
       request.challenge,
       conditionalUI,
-      request.allowCredentials
-              ?.map((e) => CredentialType(
-                  type: e.type, id: e.id, transports: e.transports))
-              .toList() ??
-          [],
+      request.allowCredentials?.map((e) => CredentialType(type: e.type, id: e.id, transports: e.transports ?? [])).toList() ?? [],
       request.preferImmediatelyAvailableCredentials,
+      salt,
     );
 
     return AuthenticateResponseType(
@@ -83,12 +74,12 @@ class PasskeysDarwin extends PasskeysPlatform {
       authenticatorData: r.authenticatorData,
       signature: r.signature,
       userHandle: r.userHandle ?? '',
+      clientExtensionResults: r.clientExtensionResults,
     );
   }
 
   @override
-  Future<void> cancelCurrentAuthenticatorOperation() =>
-      _api.cancelCurrentAuthenticatorOperation();
+  Future<void> cancelCurrentAuthenticatorOperation() => _api.cancelCurrentAuthenticatorOperation();
 
   @override
   Future<AvailabilityTypeIOS> getAvailability() async {

--- a/packages/passkeys/passkeys_darwin/lib/passkeys_darwin.dart
+++ b/packages/passkeys/passkeys_darwin/lib/passkeys_darwin.dart
@@ -21,7 +21,7 @@ class PasskeysDarwin extends PasskeysPlatform {
   Future<bool> canAuthenticate() async => _api.canAuthenticate();
 
   @override
-  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async {
+  Future<RegisterResponseType> register(RegisterRequestType request, String? salt) async {
     final userArg = User(name: request.user.name, id: request.user.id);
     final relyingPartyArg = RelyingParty(
       name: request.relyingParty.name,
@@ -52,7 +52,7 @@ class PasskeysDarwin extends PasskeysPlatform {
   }
 
   @override
-  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt}) async {
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, String? salt) async {
     var conditionalUI = false;
     if (request.mediation == MediationType.Conditional) {
       conditionalUI = true;

--- a/packages/passkeys/passkeys_darwin/pigeons/messages.dart
+++ b/packages/passkeys/passkeys_darwin/pigeons/messages.dart
@@ -130,9 +130,9 @@ abstract class PasskeysApi {
     bool canBePlatformAuthenticator,
     bool canBeSecurityKey,
     String? residentKeyPreference,
-    String? attestationPreference,
+    String? attestationPreference, {
     String? salt,
-  );
+  });
 
   @async
   AuthenticateResponse authenticate(

--- a/packages/passkeys/passkeys_darwin/pigeons/messages.dart
+++ b/packages/passkeys/passkeys_darwin/pigeons/messages.dart
@@ -58,6 +58,7 @@ class RegisterResponse {
     required this.clientDataJSON,
     required this.attestationObject,
     required this.transports,
+    this.clientExtensionResults = const {},
   });
 
   /// The ID
@@ -74,6 +75,9 @@ class RegisterResponse {
 
   /// The supported transports for the authenticator
   final List<String?> transports;
+
+  /// The clientExtensionResults - PRF results
+  final Map<String?, Object?>? clientExtensionResults;
 }
 
 /// Represents an authenticate response
@@ -86,6 +90,7 @@ class AuthenticateResponse {
     required this.authenticatorData,
     required this.signature,
     this.userHandle,
+    this.clientExtensionResults = const {},
   });
 
   /// The ID
@@ -104,6 +109,9 @@ class AuthenticateResponse {
   final String signature;
 
   final String? userHandle;
+
+  /// The clientExtensionResults - PRF results
+  final Map<String?, Object?>? clientExtensionResults;
 }
 
 @HostApi()
@@ -123,6 +131,7 @@ abstract class PasskeysApi {
     bool canBeSecurityKey,
     String? residentKeyPreference,
     String? attestationPreference,
+    String? salt,
   );
 
   @async
@@ -131,8 +140,9 @@ abstract class PasskeysApi {
     String challenge,
     bool conditionalUI,
     List<CredentialType> allowedCredentials,
-    bool preferImmediatelyAvailableCredentials,
-  );
+    bool preferImmediatelyAvailableCredentials, {
+    String? salt,
+  });
 
   @async
   void cancelCurrentAuthenticatorOperation();

--- a/packages/passkeys/passkeys_darwin/pigeons/messages.dart
+++ b/packages/passkeys/passkeys_darwin/pigeons/messages.dart
@@ -61,9 +61,6 @@ class RegisterResponse {
     this.clientExtensionResults = const {},
   });
 
-  /// The PRF
-  final String? prf;
-
   /// The ID
   final String id;
 
@@ -133,9 +130,9 @@ abstract class PasskeysApi {
     bool canBePlatformAuthenticator,
     bool canBeSecurityKey,
     String? residentKeyPreference,
-    String? attestationPreference, {
+    String? attestationPreference,
     String? salt,
-  });
+  );
 
   @async
   AuthenticateResponse authenticate(
@@ -143,9 +140,9 @@ abstract class PasskeysApi {
     String challenge,
     bool conditionalUI,
     List<CredentialType> allowedCredentials,
-    bool preferImmediatelyAvailableCredentials, {
+    bool preferImmediatelyAvailableCredentials,
     String? salt,
-  });
+  );
 
   @async
   void cancelCurrentAuthenticatorOperation();

--- a/packages/passkeys/passkeys_darwin/pigeons/messages.dart
+++ b/packages/passkeys/passkeys_darwin/pigeons/messages.dart
@@ -58,7 +58,11 @@ class RegisterResponse {
     required this.clientDataJSON,
     required this.attestationObject,
     required this.transports,
+    this.prf,
   });
+
+  /// The PRF
+  final String? prf;
 
   /// The ID
   final String id;
@@ -123,6 +127,7 @@ abstract class PasskeysApi {
     bool canBeSecurityKey,
     String? residentKeyPreference,
     String? attestationPreference,
+    String? salt,
   );
 
   @async

--- a/packages/passkeys/passkeys_platform_interface/lib/method_channel_passkeys.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/method_channel_passkeys.dart
@@ -8,10 +8,10 @@ class MethodChannelPasskeys extends PasskeysPlatform {
   Future<bool> canAuthenticate() async => throw UnimplementedError();
 
   @override
-  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async => throw UnimplementedError();
+  Future<RegisterResponseType> register(RegisterRequestType request, String? salt) async => throw UnimplementedError();
 
   @override
-  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt}) => throw UnimplementedError();
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, String? salt) => throw UnimplementedError();
 
   @override
   Future<void> cancelCurrentAuthenticatorOperation() {

--- a/packages/passkeys/passkeys_platform_interface/lib/method_channel_passkeys.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/method_channel_passkeys.dart
@@ -8,16 +8,10 @@ class MethodChannelPasskeys extends PasskeysPlatform {
   Future<bool> canAuthenticate() async => throw UnimplementedError();
 
   @override
-  Future<RegisterResponseType> register(
-    RegisterRequestType request,
-  ) async =>
-      throw UnimplementedError();
+  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async => throw UnimplementedError();
 
   @override
-  Future<AuthenticateResponseType> authenticate(
-    AuthenticateRequestType request,
-  ) =>
-      throw UnimplementedError();
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt}) => throw UnimplementedError();
 
   @override
   Future<void> cancelCurrentAuthenticatorOperation() {

--- a/packages/passkeys/passkeys_platform_interface/lib/passkeys_platform_interface.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/passkeys_platform_interface.dart
@@ -40,14 +40,12 @@ abstract class PasskeysPlatform extends PlatformInterface {
   /// Handles the platform-specific steps for the registration flow
   /// (see https://webauthn.guide/#registration)
   /// Namely it creates a public/private key pair (only the public key will be returned)
-  Future<RegisterResponseType> register(RegisterRequestType request);
+  Future<RegisterResponseType> register(RegisterRequestType request, String salt);
 
   /// Handles the platform-specific steps for the authentication flow
   /// (see https://webauthn.guide/#authentication)
   /// Namely it creates a signature for the challenge issued by the relying party
-  Future<AuthenticateResponseType> authenticate(
-    AuthenticateRequestType request,
-  );
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt});
 
   /// Cancels the ongoing authenticator operation (if there is one).
   /// This is important for the case when conditional UI has been started but

--- a/packages/passkeys/passkeys_platform_interface/lib/passkeys_platform_interface.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/passkeys_platform_interface.dart
@@ -40,12 +40,12 @@ abstract class PasskeysPlatform extends PlatformInterface {
   /// Handles the platform-specific steps for the registration flow
   /// (see https://webauthn.guide/#registration)
   /// Namely it creates a public/private key pair (only the public key will be returned)
-  Future<RegisterResponseType> register(RegisterRequestType request, String salt);
+  Future<RegisterResponseType> register(RegisterRequestType request, String? salt);
 
   /// Handles the platform-specific steps for the authentication flow
   /// (see https://webauthn.guide/#authentication)
   /// Namely it creates a signature for the challenge issued by the relying party
-  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt});
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, String? salt);
 
   /// Cancels the ongoing authenticator operation (if there is one).
   /// This is important for the case when conditional UI has been started but

--- a/packages/passkeys/passkeys_platform_interface/lib/types/authenticate_response.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/authenticate_response.dart
@@ -2,13 +2,15 @@ import 'dart:convert';
 
 class AuthenticateResponseType {
   /// Constructs a new instance.
-  const AuthenticateResponseType(
-      {required this.id,
-      required this.rawId,
-      required this.clientDataJSON,
-      required this.authenticatorData,
-      required this.signature,
-      required this.userHandle});
+  const AuthenticateResponseType({
+    required this.id,
+    required this.rawId,
+    required this.clientDataJSON,
+    required this.authenticatorData,
+    required this.signature,
+    required this.userHandle,
+    this.clientExtensionResults,
+  });
 
   /// Constructs a new instance from a JSON string.
   factory AuthenticateResponseType.fromJsonString(String jsonString) {
@@ -27,8 +29,7 @@ class AuthenticateResponseType {
     if (json.containsKey('response')) {
       final response = json['response'];
       if (response is! Map<String, dynamic>) {
-        throw FormatException(
-            'Expected "response" to be a Map, got ${response.runtimeType}');
+        throw FormatException('Expected "response" to be a Map, got ${response.runtimeType}');
       }
       return AuthenticateResponseType(
         id: json['id'] as String? ?? '',
@@ -37,6 +38,7 @@ class AuthenticateResponseType {
         authenticatorData: response['authenticatorData'] as String? ?? '',
         signature: response['signature'] as String? ?? '',
         userHandle: (response['userHandle'] as String?) ?? '',
+        clientExtensionResults: json['clientExtensionResults'] as Map<String, Object>?,
       );
     }
 
@@ -48,6 +50,7 @@ class AuthenticateResponseType {
       authenticatorData: json['authenticatorData'] as String? ?? '',
       signature: json['signature'] as String? ?? '',
       userHandle: (json['userHandle'] as String?) ?? '',
+      clientExtensionResults: json['clientExtensionResults'] as Map<String, Object>?,
     );
   }
 
@@ -69,6 +72,9 @@ class AuthenticateResponseType {
   /// The user handle. Can be empty if the user handle is not available.
   final String userHandle;
 
+  /// Optional client extension results.
+  final Map<String?, Object?>? clientExtensionResults;
+
   /// Converts this instance to a JSON string.
   String toJsonString() => jsonEncode(toJson());
 
@@ -76,23 +82,28 @@ class AuthenticateResponseType {
   ///
   /// Output follows the standard WebAuthn format with nested 'response' object.
   Map<String, dynamic> toJson() {
-    final response = <String, dynamic>{
-      'clientDataJSON': clientDataJSON,
-      'authenticatorData': authenticatorData,
-      'signature': signature,
-    };
+    Map<String, dynamic>? sanitizedExtensions;
+
+    final response = <String, dynamic>{'clientDataJSON': clientDataJSON, 'authenticatorData': authenticatorData, 'signature': signature};
 
     // Only include userHandle if it's not empty
     if (userHandle.isNotEmpty) {
       response['userHandle'] = userHandle;
     }
 
-    return {
-      'id': id,
-      'rawId': rawId,
-      'type': 'public-key',
-      'response': response,
-      'clientExtensionResults': <String, dynamic>{},
-    };
+    if (clientExtensionResults != null) {
+      sanitizedExtensions = {};
+
+      final prf = clientExtensionResults?['prf'] as Map?;
+      final results = prf?['results'] as Map?;
+
+      if (results != null) {
+        sanitizedExtensions['prf'] = {
+          'results': {'first': ''},
+        };
+      }
+    }
+
+    return {'id': id, 'rawId': rawId, 'type': 'public-key', 'response': response, 'clientExtensionResults': sanitizedExtensions ?? <String, dynamic>{}};
   }
 }

--- a/packages/passkeys/passkeys_platform_interface/lib/types/authenticator_selection.g.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/authenticator_selection.g.dart
@@ -7,20 +7,19 @@ part of 'authenticator_selection.dart';
 // **************************************************************************
 
 AuthenticatorSelectionType _$AuthenticatorSelectionTypeFromJson(
-        Map<String, dynamic> json) =>
-    AuthenticatorSelectionType(
-      authenticatorAttachment: json['authenticatorAttachment'] as String?,
-      requireResidentKey: json['requireResidentKey'] as bool,
-      residentKey: json['residentKey'] as String,
-      userVerification: json['userVerification'] as String,
-    );
+  Map<String, dynamic> json,
+) => AuthenticatorSelectionType(
+  authenticatorAttachment: json['authenticatorAttachment'] as String?,
+  requireResidentKey: json['requireResidentKey'] as bool,
+  residentKey: json['residentKey'] as String,
+  userVerification: json['userVerification'] as String,
+);
 
 Map<String, dynamic> _$AuthenticatorSelectionTypeToJson(
-        AuthenticatorSelectionType instance) =>
-    <String, dynamic>{
-      if (instance.authenticatorAttachment case final value?)
-        'authenticatorAttachment': value,
-      'requireResidentKey': instance.requireResidentKey,
-      'residentKey': instance.residentKey,
-      'userVerification': instance.userVerification,
-    };
+  AuthenticatorSelectionType instance,
+) => <String, dynamic>{
+  'authenticatorAttachment': ?instance.authenticatorAttachment,
+  'requireResidentKey': instance.requireResidentKey,
+  'residentKey': instance.residentKey,
+  'userVerification': instance.userVerification,
+};

--- a/packages/passkeys/passkeys_platform_interface/lib/types/credential.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/credential.dart
@@ -14,8 +14,7 @@ class CredentialType {
   });
 
   /// Constructs a new instance from a JSON map.
-  factory CredentialType.fromJson(Map<String, dynamic> json) =>
-      _$CredentialTypeFromJson(json);
+  factory CredentialType.fromJson(Map<String, dynamic> json) => _$CredentialTypeFromJson(json);
 
   /// The type of the credential.
   final String type;
@@ -24,7 +23,7 @@ class CredentialType {
   final String id;
 
   /// The transports of the credential.
-  final List<String> transports;
+  final List<String>? transports;
 
   /// Converts this instance to a JSON map.
   Map<String, dynamic> toJson() => _$CredentialTypeToJson(this);

--- a/packages/passkeys/passkeys_platform_interface/lib/types/credential.g.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/credential.g.dart
@@ -10,8 +10,8 @@ CredentialType _$CredentialTypeFromJson(Map<String, dynamic> json) =>
     CredentialType(
       type: json['type'] as String,
       id: json['id'] as String,
-      transports: (json['transports'] as List<dynamic>)
-          .map((e) => e as String)
+      transports: (json['transports'] as List<dynamic>?)
+          ?.map((e) => e as String)
           .toList(),
     );
 

--- a/packages/passkeys/passkeys_platform_interface/lib/types/pubkeycred_param.g.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/pubkeycred_param.g.dart
@@ -13,8 +13,5 @@ PubKeyCredParamType _$PubKeyCredParamTypeFromJson(Map<String, dynamic> json) =>
     );
 
 Map<String, dynamic> _$PubKeyCredParamTypeToJson(
-        PubKeyCredParamType instance) =>
-    <String, dynamic>{
-      'type': instance.type,
-      'alg': instance.alg,
-    };
+  PubKeyCredParamType instance,
+) => <String, dynamic>{'type': instance.type, 'alg': instance.alg};

--- a/packages/passkeys/passkeys_platform_interface/lib/types/relying_party.g.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/relying_party.g.dart
@@ -7,13 +7,7 @@ part of 'relying_party.dart';
 // **************************************************************************
 
 RelyingPartyType _$RelyingPartyTypeFromJson(Map<String, dynamic> json) =>
-    RelyingPartyType(
-      name: json['name'] as String,
-      id: json['id'] as String,
-    );
+    RelyingPartyType(name: json['name'] as String, id: json['id'] as String);
 
 Map<String, dynamic> _$RelyingPartyTypeToJson(RelyingPartyType instance) =>
-    <String, dynamic>{
-      'name': instance.name,
-      'id': instance.id,
-    };
+    <String, dynamic>{'name': instance.name, 'id': instance.id};

--- a/packages/passkeys/passkeys_platform_interface/lib/types/user.g.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/user.g.dart
@@ -7,13 +7,13 @@ part of 'user.dart';
 // **************************************************************************
 
 UserType _$UserTypeFromJson(Map<String, dynamic> json) => UserType(
-      displayName: json['displayName'] as String,
-      name: json['name'] as String,
-      id: json['id'] as String,
-    );
+  displayName: json['displayName'] as String,
+  name: json['name'] as String,
+  id: json['id'] as String,
+);
 
 Map<String, dynamic> _$UserTypeToJson(UserType instance) => <String, dynamic>{
-      'displayName': instance.displayName,
-      'name': instance.name,
-      'id': instance.id,
-    };
+  'displayName': instance.displayName,
+  'name': instance.name,
+  'id': instance.id,
+};

--- a/packages/passkeys/passkeys_platform_interface/pubspec.yaml
+++ b/packages/passkeys/passkeys_platform_interface/pubspec.yaml
@@ -5,8 +5,7 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 2.6.0
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-
+  sdk: '>=3.8.0 <4.0.0'
 dependencies:
   flutter:
     sdk: flutter

--- a/packages/passkeys/passkeys_windows/lib/messages.g.dart
+++ b/packages/passkeys/passkeys_windows/lib/messages.g.dart
@@ -374,17 +374,14 @@ class PasskeysApi {
   /// Constructor for [PasskeysApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  PasskeysApi({BinaryMessenger? binaryMessenger})
-      : _binaryMessenger = binaryMessenger;
+  PasskeysApi({BinaryMessenger? binaryMessenger}) : _binaryMessenger = binaryMessenger;
   final BinaryMessenger? _binaryMessenger;
 
   static const MessageCodec<Object?> codec = _PasskeysApiCodec();
 
   Future<bool> canAuthenticate() async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_windows.PasskeysApi.canAuthenticate',
-        codec,
-        binaryMessenger: _binaryMessenger);
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_windows.PasskeysApi.canAuthenticate', codec, binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
@@ -408,10 +405,8 @@ class PasskeysApi {
   }
 
   Future<bool> hasPasskeySupport() async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_windows.PasskeysApi.hasPasskeySupport',
-        codec,
-        binaryMessenger: _binaryMessenger);
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_windows.PasskeysApi.hasPasskeySupport', codec, binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
@@ -434,18 +429,10 @@ class PasskeysApi {
     }
   }
 
-  Future<RegisterResponse> register(
-      String arg_challenge,
-      RelyingParty arg_relyingParty,
-      User arg_user,
-      AuthenticatorSelection? arg_authenticatorSelection,
-      List<PubKeyCredParam?>? arg_pubKeyCredParams,
-      int? arg_timeout,
-      String? arg_attestation,
-      List<ExcludeCredential?> arg_excludeCredentials) async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_windows.PasskeysApi.register', codec,
-        binaryMessenger: _binaryMessenger);
+  Future<RegisterResponse> register(String arg_challenge, RelyingParty arg_relyingParty, User arg_user, AuthenticatorSelection? arg_authenticatorSelection,
+      List<PubKeyCredParam?>? arg_pubKeyCredParams, int? arg_timeout, String? arg_attestation, List<ExcludeCredential?> arg_excludeCredentials) async {
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_windows.PasskeysApi.register', codec, binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList = await channel.send(<Object?>[
       arg_challenge,
       arg_relyingParty,
@@ -477,24 +464,13 @@ class PasskeysApi {
     }
   }
 
-  Future<AuthenticateResponse> authenticate(
-      String arg_relyingPartyId,
-      String arg_challenge,
-      int? arg_timeout,
-      String? arg_userVerification,
-      List<AllowCredential?>? arg_allowCredentials,
-      bool? arg_preferImmediatelyAvailableCredentials) async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_windows.PasskeysApi.authenticate', codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(<Object?>[
-      arg_relyingPartyId,
-      arg_challenge,
-      arg_timeout,
-      arg_userVerification,
-      arg_allowCredentials,
-      arg_preferImmediatelyAvailableCredentials
-    ]) as List<Object?>?;
+  Future<AuthenticateResponse> authenticate(String arg_relyingPartyId, String arg_challenge, int? arg_timeout, String? arg_userVerification,
+      List<AllowCredential?>? arg_allowCredentials, bool? arg_preferImmediatelyAvailableCredentials) async {
+    final BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.passkeys_windows.PasskeysApi.authenticate', codec, binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(
+            <Object?>[arg_relyingPartyId, arg_challenge, arg_timeout, arg_userVerification, arg_allowCredentials, arg_preferImmediatelyAvailableCredentials])
+        as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -518,8 +494,7 @@ class PasskeysApi {
 
   Future<void> cancelCurrentAuthenticatorOperation() async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.passkeys_windows.PasskeysApi.cancelCurrentAuthenticatorOperation',
-        codec,
+        'dev.flutter.pigeon.passkeys_windows.PasskeysApi.cancelCurrentAuthenticatorOperation', codec,
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {

--- a/packages/passkeys/passkeys_windows/lib/passkeys_windows.dart
+++ b/packages/passkeys/passkeys_windows/lib/passkeys_windows.dart
@@ -16,7 +16,7 @@ class PasskeysWindows extends PasskeysPlatform {
   final PasskeysApi _api;
 
   @override
-  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt}) async {
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, String? salt) async {
     final authenticateResponse = await _api.authenticate(
       request.relyingPartyId,
       request.challenge,
@@ -55,7 +55,7 @@ class PasskeysWindows extends PasskeysPlatform {
   }
 
   @override
-  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async {
+  Future<RegisterResponseType> register(RegisterRequestType request, String? salt) async {
     final userArg = User(
       displayName: request.user.displayName,
       name: request.user.name,

--- a/packages/passkeys/passkeys_windows/lib/passkeys_windows.dart
+++ b/packages/passkeys/passkeys_windows/lib/passkeys_windows.dart
@@ -16,9 +16,7 @@ class PasskeysWindows extends PasskeysPlatform {
   final PasskeysApi _api;
 
   @override
-  Future<AuthenticateResponseType> authenticate(
-    AuthenticateRequestType request,
-  ) async {
+  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request, {String? salt}) async {
     final authenticateResponse = await _api.authenticate(
       request.relyingPartyId,
       request.challenge,
@@ -29,7 +27,7 @@ class PasskeysWindows extends PasskeysPlatform {
             (e) => AllowCredential(
               type: e.type,
               id: e.id,
-              transports: e.transports,
+              transports: e.transports ?? [],
             ),
           )
           .toList(),
@@ -57,7 +55,7 @@ class PasskeysWindows extends PasskeysPlatform {
   }
 
   @override
-  Future<RegisterResponseType> register(RegisterRequestType request) async {
+  Future<RegisterResponseType> register(RegisterRequestType request, String salt) async {
     final userArg = User(
       displayName: request.user.displayName,
       name: request.user.name,
@@ -74,8 +72,7 @@ class PasskeysWindows extends PasskeysPlatform {
 
     if (requestAuthSelectionType != null) {
       authSelection = AuthenticatorSelection(
-        authenticatorAttachment:
-            requestAuthSelectionType.authenticatorAttachment,
+        authenticatorAttachment: requestAuthSelectionType.authenticatorAttachment,
         requireResidentKey: requestAuthSelectionType.requireResidentKey,
         residentKey: requestAuthSelectionType.residentKey,
         userVerification: requestAuthSelectionType.userVerification,
@@ -87,14 +84,10 @@ class PasskeysWindows extends PasskeysPlatform {
       relyingPartyArg,
       userArg,
       authSelection,
-      request.pubKeyCredParams
-          ?.map((e) => PubKeyCredParam(type: e.type, alg: e.alg))
-          .toList(),
+      request.pubKeyCredParams?.map((e) => PubKeyCredParam(type: e.type, alg: e.alg)).toList(),
       request.timeout,
       request.attestation,
-      request.excludeCredentials
-          .map((e) => ExcludeCredential(type: e.type, id: e.id))
-          .toList(),
+      request.excludeCredentials.map((e) => ExcludeCredential(type: e.type, id: e.id)).toList(),
     );
 
     return RegisterResponseType(
@@ -107,20 +100,17 @@ class PasskeysWindows extends PasskeysPlatform {
   }
 
   @override
-  Future<void> cancelCurrentAuthenticatorOperation() =>
-      _api.cancelCurrentAuthenticatorOperation();
+  Future<void> cancelCurrentAuthenticatorOperation() => _api.cancelCurrentAuthenticatorOperation();
 
   @override
   Future<AvailabilityTypeWindows> getAvailability() async {
-    final isUserVerifyingPlatformAuthenticatorAvailable =
-        await canAuthenticate();
+    final isUserVerifyingPlatformAuthenticatorAvailable = await canAuthenticate();
 
     final hasPasskeySupport = await _api.hasPasskeySupport();
 
     return AvailabilityTypeWindows(
       hasPasskeySupport: hasPasskeySupport,
-      isUserVerifyingPlatformAuthenticatorAvailable:
-          isUserVerifyingPlatformAuthenticatorAvailable,
+      isUserVerifyingPlatformAuthenticatorAvailable: isUserVerifyingPlatformAuthenticatorAvailable,
       isNative: true,
     );
   }


### PR DESCRIPTION
What’s Changed
• Added PRF support for both Android and iOS
• Updated json_annotation to support nullable properties
• Increased the minimum iOS version from 12 to 13 (there’s little value in supporting such an old version)
• Removed usePubspecOverrides, as it’s no longer supported in the latest version of Melos

Before merging please ensure you update the pubspec yaml to refer to the correct packages. You may also need to bump the version for each of these packages

[packages/passkeys/passkeys/pubspec.yaml](https://github.com/corbado/flutter-passkeys/compare/main...fountain-fm:flutter-passkeys:thomas/prf#diff-fd168f1e27da9b41a3bb1f9d65c9ac39ae4a2af427a1bfec75c600a47422ef5d)