### PR TITLE
Feat/passkeys darwin swiftpm support

### DIFF
--- a/packages/passkeys/passkeys/CHANGELOG.md
+++ b/packages/passkeys/passkeys/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.19.0
+* Updates `passkeys_darwin` dependency to `^0.4.0` to add Swift Package Manager support for iOS/macOS.
+
 ## 2.18.0
 * Adds `NoCreateOptionException` handling for register flow. (Android)
 * Updates `passkeys_doctor` dependency to `^1.3.0`.

--- a/packages/passkeys/passkeys/pubspec.yaml
+++ b/packages/passkeys/passkeys/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
     sdk: flutter
   json_annotation: ^4.8.1
   passkeys_android: ^2.12.0
-  passkeys_darwin: ^0.3.0
+  passkeys_darwin: ^0.4.0
   passkeys_doctor: ^1.3.0
   passkeys_platform_interface: ^2.6.0
   passkeys_web: ^2.8.1

--- a/packages/passkeys/passkeys_darwin/CHANGELOG.md
+++ b/packages/passkeys/passkeys_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Adds Swift Package Manager support for the Darwin plugin (iOS & macOS).
+
 ## 0.3.0
 
 - Passes `Attestation` and `ResidentKey` params to Security Key Register Handler

--- a/packages/passkeys/passkeys_darwin/Package.swift
+++ b/packages/passkeys/passkeys_darwin/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "passkeys_darwin",
+    platforms: [
+        .iOS("9.0"),
+        .macOS("10.15")
+    ],
+    products: [
+        .library(
+            name: "passkeys-darwin",
+            targets: ["passkeys_darwin"]
+        )
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "passkeys_darwin",
+            dependencies: [],
+            path: "darwin/Classes",
+            resources: []
+        )
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/packages/passkeys/passkeys_darwin/pubspec.yaml
+++ b/packages/passkeys/passkeys_darwin/pubspec.yaml
@@ -2,7 +2,7 @@ name: passkeys_darwin
 description: Shared Darwin implementation (iOS & macOS) of the Corbado passkeys plugin. Manages passkey creation on Apple devices.
 homepage: https://docs.corbado.com/overview/welcome
 repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passkeys/passkeys_darwin
-version: 0.3.0
+version: 0.4.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
This PR adds **Swift Package Manager (SwiftPM) support** for the Apple federated implementation of `passkeys`, while preserving existing CocoaPods compatibility.

Flutter is migrating plugin integration toward SwiftPM, and this change prepares the plugin for that transition.

## Changes

### `packages/passkeys/passkeys_darwin`
- Added `Package.swift` to enable SwiftPM integration for iOS/macOS.
- Bumped version:
  - `0.3.0` → `0.4.0`
- Updated changelog:
  - Added `0.4.0` entry for SwiftPM support.

### `packages/passkeys/passkeys`
- Updated dependency:
  - `passkeys_darwin: ^0.4.0`
- Updated changelog:
  - Added `2.19.0` entry noting darwin dependency bump for SwiftPM support.

## Notes
- CocoaPods support remains intact (backward compatibility).
- Runtime behavior for iOS versions below passkey availability is unchanged (feature remains runtime-gated and reports unsupported where applicable).