### PR TITLE
fix(passkeys_doctor): widen device_info_plus constraint to allow ^12.0.0

### DIFF
--- a/packages/passkeys/passkeys_doctor/pubspec.yaml
+++ b/packages/passkeys/passkeys_doctor/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.3.0
-  device_info_plus: ^11.2.0
+  device_info_plus: ">=11.2.0 <13.0.0"
   package_info_plus: ^9.0.0
   passkeys_platform_interface: ^2.4.0
   passkeys_ios: ^2.6.1

--- a/packages/passkeys/passkeys_doctor/pubspec.yaml
+++ b/packages/passkeys/passkeys_doctor/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.3.0
-  device_info_plus: ">=11.2.0 <13.0.0"
+  device_info_plus: ">=11.2.0 <14.0.0"
   package_info_plus: ^9.0.0
   passkeys_platform_interface: ^2.4.0
   passkeys_ios: ^2.6.1


### PR DESCRIPTION
 The `device_info_plus` constraint in `passkeys_doctor` is currently pinned to `^11.2.0`, which prevents any project that also uses a package requiring `device_info_plus ^12.0.0` from upgrading `passkeys` past 2.8.2.

In my case `livekit_client` needs `device_info_plus ^12.3.0`, but any package depending on `device_info_plus 12.x` would hit the same wall.

The only usage of `device_info_plus` in `passkeys_doctor` is `DeviceInfoPlugin().iosInfo`, which hasn't changed between v11 and v12, so widening the constraint to `>=11.2.0 <13.0.0` should be safe.
