### PR TITLE
feat(passkeys_doctor): widen package_info_plus to >=9.0.0 <11.0.0 (closes #240)

### DIFF
--- a/packages/passkeys/passkeys_doctor/CHANGELOG.md
+++ b/packages/passkeys/passkeys_doctor/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+* Widens `package_info_plus` constraint to `>=9.0.0 <11.0.0` to unblock consumers on `package_info_plus` 10.x. The only call site (`PackageInfo.fromPlatform().packageName`) is API-stable across the 9 → 10 bump. Unblocks downstream apps that need `share_plus 13.x` / `win32 ^6.0.1`. See https://github.com/corbado/flutter-passkeys/issues/240.
+
 ## 1.3.1
 
 * Widens `device_info_plus` constraint to `>=11.2.0 <14.0.0` to unblock consumers on `device_info_plus` 12.x.

--- a/packages/passkeys/passkeys_doctor/pubspec.yaml
+++ b/packages/passkeys/passkeys_doctor/pubspec.yaml
@@ -2,7 +2,7 @@ name: passkeys_doctor
 description: "Internal debugging tools used to help with passkeys package."
 homepage: https://docs.corbado.com/overview/welcome
 repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passkeys/passkeys_doctor
-version: 1.3.1
+version: 1.4.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -13,7 +13,14 @@ dependencies:
     sdk: flutter
   http: ^1.3.0
   device_info_plus: ">=11.2.0 <14.0.0"
-  package_info_plus: ^9.0.0
+  # Widened from ^9.0.0 to allow ^10.0.0 too. The only call site
+  # (`PackageInfo.fromPlatform().packageName` in
+  # `lib/src/passkeys_doctor.dart::_getBundleId`) is API-stable
+  # across the 9 → 10 bump. Keeping the lower bound at 9.0.0 so
+  # existing consumers on package_info_plus 9.x are not forced to
+  # upgrade. See https://github.com/corbado/flutter-passkeys/issues/240
+  # for the downstream win32-6 chain this unblocks.
+  package_info_plus: ">=9.0.0 <11.0.0"
   passkeys_platform_interface: ^2.4.0
   passkeys_ios: ^2.6.1
 


### PR DESCRIPTION
## Summary

Bumps `passkeys_doctor` `1.3.1 → 1.4.0` with the `package_info_plus` constraint widened from `^9.0.0` to `>=9.0.0 <11.0.0`. This is the smallest possible change that unblocks the entire downstream `win32 ^6` chain (`share_plus 13`, `flutter_secure_storage_windows 4.2.x`, `package_info_plus 10`) for apps that depend on `passkeys`.

Closes #240.

## Why this is API-safe

`passkeys_doctor` uses `package_info_plus` in exactly one place:

```dart
// packages/passkeys/passkeys_doctor/lib/src/passkeys_doctor.dart::_getBundleId
final info = await PackageInfo.fromPlatform();
return info.packageName;
```

`PackageInfo.fromPlatform()` and the `packageName` getter have been stable since the 1.x line. The breaking changes in `package_info_plus 10.0.0` are entirely in the Windows platform implementation (moves to a `win32 ^6` method channel) and do not touch the public API.

Keeping the lower bound at `9.0.0` so existing consumers on `package_info_plus 9.x` are not forced to upgrade.

## Why this matters downstream

`package_info_plus 9` depends on `win32 ^5.5.3`. With `passkeys_doctor` pinned to `package_info_plus ^9.0.0`, every Flutter app that depends on `passkeys` is held on `win32 5.x`. Recent ecosystem releases — `share_plus 13.1.0`, `flutter_secure_storage_windows 4.2.x`, the actual `win32 6.2.0` release — all require `win32 ^6.0.1`. Net effect: any app using `passkeys` can't pick up the `CryptProtectData` / `LocalFree` typing fixes that landed in `win32 6` for Windows desktop.

After this change, the parent `passkeys` package already accepts `passkeys_doctor: ^1.3.0` (i.e. `<2.0.0`), so once `1.4.0` ships to pub.dev no version bump is needed in the `passkeys` package itself.

## Verified locally

- `flutter pub get` in `packages/passkeys/passkeys_doctor` resolves cleanly and now pulls in `win32 6.2.0` transitively.
- `flutter analyze` in `packages/passkeys/passkeys_doctor` → `No issues found`.

## Changes

- `packages/passkeys/passkeys_doctor/pubspec.yaml`: version + constraint
- `packages/passkeys/passkeys_doctor/CHANGELOG.md`: `1.4.0` entry

## Test plan

- [x] `flutter pub get` resolves with widened constraint
- [x] `flutter analyze` clean
- [ ] Maintainer verifies CI on the workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)