### PR TITLE
chore: raise min Dart SDK to 3.4.0 to match web ^1.1.1

### DIFF
--- a/packages/passkeys/passkeys/pubspec.yaml
+++ b/packages/passkeys/passkeys/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 2.19.0
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.4.0 <4.0.0"
   flutter: ">=3.0.0"
 
 flutter:

--- a/packages/passkeys/passkeys_web/pubspec.yaml
+++ b/packages/passkeys/passkeys_web/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 2.8.1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.4.0 <4.0.0"
   flutter: ">=3.19.0"
 
 flutter:


### PR DESCRIPTION
## What

Raise the minimum Dart SDK from `>=3.0.0` to `>=3.4.0` in `passkeys_web` and `passkeys`.

## Why

`passkeys_web` depends on `web: ^1.1.1`, and `web >=1.0.0` requires Dart `>=3.4.0`. However `passkeys_web` (and the top-level `passkeys`, which depends on it) still declare `sdk: ">=3.0.0 <4.0.0"`. The declared minimum is therefore lower than the real one.

On a project using Dart 3.3.x this surfaces as a confusing transitive version-solving failure rather than a clear "this package needs Dart 3.4.0":

```
Because passkeys >=2.17.4 depends on passkeys_web ^2.8.1 which depends on web ^1.1.1,
passkeys >=2.17.4 requires web ^1.1.1.
So, because web >=1.0.0 requires SDK version >=3.4.0 <4.0.0 and <app> depends on passkeys ^2.19.0,
version solving failed.
```

Declaring the real minimum makes the constraint honest and gives consumers a clear error pointing at the SDK requirement.

## Notes

- This is the minimum that actually resolves today, so it does not change which SDKs can use the package, only what the metadata reports. Pub already refuses to install these versions on Dart < 3.4.0.
- Scope kept to the two packages that carry the `web ^1.1.1` requirement (`passkeys_web` directly, `passkeys` transitively). Happy to extend the bump to the other packages in the monorepo if you prefer a uniform floor.