### PR TITLE
fix: use flutter.compileSdkVersion instead of hardcoded 35 in passkey…

### DIFF
--- a/packages/passkeys/passkeys_doctor/android/build.gradle
+++ b/packages/passkeys/passkeys_doctor/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: "com.android.library"
 android {
     namespace = "com.corbado.passkeys_doctor"
 
-    compileSdk = 35
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
Fix passkeys_doctor compileSdk compatibility with newer Flutter plugins

Problem

passkeys_doctor hardcodes compileSdk = 35 in its Android build.gradle, ignoring the flutter.compileSdkVersion extension provided by the Flutter Gradle plugin. This causes a build failure when used alongside plugins like device_info_plus and package_info_plus that now require compileSdk >= 36:

Dependency ':device_info_plus' requires libraries and applications that
depend on it to compile against version 36 or later of the Android APIs.
:passkeys_doctor is currently compiled against android-35.

Fix

Replace the hardcoded value with flutter.compileSdkVersion, consistent with how other well-behaved Flutter plugins (e.g., device_info_plus, package_info_plus, sentry_flutter) declare their compileSdk:

-    compileSdk = 35
+    compileSdk = flutter.compileSdkVersion

Why this works

The Flutter Gradle plugin creates a flutter extension on every plugin project (via PluginHandler.configurePluginProject), which exposes compileSdkVersion — currently 36 in Flutter 3.44.2. Plugins that use this extension automatically stay compatible with the project's SDK version without requiring manual updates on each Flutter release.