### PR TITLE
feat: add PasskeyAuthenticatorInterface implemented by PasskeyAuthenticator

### DIFF
--- a/packages/passkeys/passkeys/lib/authenticator.dart
+++ b/packages/passkeys/passkeys/lib/authenticator.dart
@@ -7,7 +7,7 @@ import 'package:passkeys_platform_interface/passkeys_platform_interface.dart';
 
 /// Handles platform dependent parts of the registration and authentication
 /// flow.
-class PasskeyAuthenticator {
+class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
   /// Constructor
   PasskeyAuthenticator({bool? debugMode})
       : _platform = PasskeysPlatform.instance,

--- a/packages/passkeys/passkeys/lib/types.dart
+++ b/packages/passkeys/passkeys/lib/types.dart
@@ -1,5 +1,6 @@
 export 'package:passkeys/exceptions.dart';
 export 'package:passkeys_doctor/passkeys_doctor.dart';
+export 'package:passkeys_platform_interface/passkey_authenticator_interface.dart';
 export 'package:passkeys_platform_interface/types/authenticator_selection.dart';
 export 'package:passkeys_platform_interface/types/credential.dart';
 export 'package:passkeys_platform_interface/types/pubkeycred_param.dart';

--- a/packages/passkeys/passkeys_platform_interface/lib/passkey_authenticator_interface.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/passkey_authenticator_interface.dart
@@ -1,0 +1,19 @@
+import 'package:passkeys_platform_interface/types/types.dart';
+
+/// Interface for authenticators that perform the platform WebAuthn ceremonies.
+///
+/// The `passkeys` package's `PasskeyAuthenticator` implements this interface.
+/// Depending on this interface (instead of the `passkeys` package directly)
+/// lets a package accept an authenticator without taking on the full plugin and
+/// its platform requirements.
+abstract interface class PasskeyAuthenticatorInterface {
+  /// Creates a new passkey on the device for the given [request] and returns
+  /// the credential that must be sent to the relying party server.
+  Future<RegisterResponseType> register(RegisterRequestType request);
+
+  /// Authenticates the user with a passkey for the given [request] and returns
+  /// the assertion that must be sent to the relying party server.
+  Future<AuthenticateResponseType> authenticate(
+    AuthenticateRequestType request,
+  );
+}

--- a/packages/passkeys/passkeys_platform_interface/lib/passkeys_platform_interface.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/passkeys_platform_interface.dart
@@ -3,6 +3,8 @@ import 'package:passkeys_platform_interface/types/availability.dart';
 import 'package:passkeys_platform_interface/types/types.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+export 'package:passkeys_platform_interface/passkey_authenticator_interface.dart';
+
 /// The interface that implementations of passkeys must implement.
 ///
 /// Platform implementations should extend this class


### PR DESCRIPTION
## What

Adds a `PasskeyAuthenticatorInterface` to `passkeys_platform_interface` and makes the `passkeys` package's `PasskeyAuthenticator` implement it.

```dart
// passkeys_platform_interface/lib/passkey_authenticator_interface.dart
abstract interface class PasskeyAuthenticatorInterface {
  Future<RegisterResponseType> register(RegisterRequestType request);
  Future<AuthenticateResponseType> authenticate(AuthenticateRequestType request);
}
```

```dart
// passkeys/lib/authenticator.dart
class PasskeyAuthenticator implements PasskeyAuthenticatorInterface { ... }
```

The interface is re-exported from `passkeys_platform_interface.dart`.

## Why

Packages that integrate passkeys (for example Supabase's [`supabase_flutter`](https://pub.dev/packages/supabase_flutter)) often only need to hand a `RegisterRequestType`/`AuthenticateRequestType` to an authenticator and read back the response. To do that today they must depend on the full `passkeys` plugin, which forces **every** consumer of their package to raise minimum platform versions (iOS 16.0 / macOS 13.5) and pull in the plugin's transitive dependencies, even when passkeys are never used.

With this interface, such a package can depend only on `passkeys_platform_interface` and accept a `PasskeyAuthenticatorInterface`. Apps that want passkeys add the `passkeys` plugin themselves and pass their `PasskeyAuthenticator` straight in; apps that do not are unaffected.

## Non-breaking

`PasskeyAuthenticator.register` and `.authenticate` already have exactly the signatures the interface declares, so `implements` only adds a supertype. No method, behavior, or public-API changes.

## Notes

- Versions, CHANGELOGs, and the intra-workspace `passkeys_platform_interface` constraint bump are left to the Melos release tooling.
- `flutter analyze` passes for both packages (the `implements` clause resolves cleanly, confirming the class satisfies the interface). The only analyzer output is pre-existing `info`-level lints in unrelated files.

Happy to adjust naming, file location, or whether the interface should also be re-exported from `passkeys/types.dart` to match your preferences.