### PR TITLE
ci: skip Vercel deploy on fork PRs and add analyze/test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  analyze-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.27.4"
+
+      - name: Set up melos
+        uses: bluefireteam/melos-action@v3
+
+      - name: Check formatting
+        run: melos run format:check
+
+      - name: Analyze
+        run: melos run analyze
+
+      - name: Test
+        run: melos run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.4"
+          flutter-version: "3.32.0"
 
       - name: Set up melos
         uses: bluefireteam/melos-action@v3

--- a/.github/workflows/deploy-corbado-auth-example.yml
+++ b/.github/workflows/deploy-corbado-auth-example.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Secrets are not available to pull_request workflows from forks, so the
+    # Vercel deploy would fail. Skip the job for those PRs instead.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-passkeys-example.yml
+++ b/.github/workflows/deploy-passkeys-example.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Secrets are not available to pull_request workflows from forks, so the
+    # Vercel deploy would fail. Skip the job for those PRs instead.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What

Two CI changes:

1. **Skip the Vercel deploy job on fork PRs.** Adds a job-level condition to both deploy workflows so the `deploy` job is skipped (rather than failed) for pull requests originating from a fork:

   ```yaml
   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
   ```

2. **Add a CI workflow** (`.github/workflows/ci.yml`) that runs formatting check, analysis, and tests on every push to `main` and every pull request. It uses `bluefireteam/melos-action` to install melos and bootstrap, then runs the existing melos scripts:

   ```yaml
   - run: melos run format:check
   - run: melos run analyze
   - run: melos run test
   ```

## Why

### Vercel deploy fix

GitHub does not expose repository secrets to `pull_request`-triggered workflows from forks. As a result `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` are empty for any fork PR, and the deploy step expands to:

```bash
npx vercel deploy --prebuilt -t        # -t has no argument
# _ArgError: option requires argument: --token (ARG_MISSING_REQUIRED_LONGARG)
```

This fails CI on every fork PR (for example [this run](https://github.com/corbado/flutter-passkeys/actions/runs/28354792250/job/83995214208?pr=247)), unrelated to the PR's actual changes. With this change the job is cleanly skipped for fork PRs, while `push` to `main`, `release`, and same-repo PRs keep deploying as before.

### CI workflow

There was no automated formatting, analysis, or test check running on PRs. This adds one so regressions are caught before merge. It needs no secrets, so it runs on fork PRs too.