### PR TITLE
chore: require Dart SDK 3.8.0 across all packages

### DIFF
--- a/.github/workflows/deploy-corbado-auth-example.yml
+++ b/.github/workflows/deploy-corbado-auth-example.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.4"
+          flutter-version: "3.32.0"
 
       - name: Normalize branch name
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-passkeys-example.yml
+++ b/.github/workflows/deploy-passkeys-example.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           # Pin to a Flutter version that your app supports
           # or omit to use the default stable version
-          flutter-version: "3.27.4"
+          flutter-version: "3.32.0"
 
       - name: Normalize branch name
         if: github.event_name == 'pull_request'

--- a/packages/corbado_api_client/lib/frontendapi/pubspec.yaml
+++ b/packages/corbado_api_client/lib/frontendapi/pubspec.yaml
@@ -4,7 +4,7 @@ description: Client for the Corbado Frontend API
 homepage: https://docs.corbado.com/overview/welcome
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   dio: '^5.2.0'

--- a/packages/corbado_api_client/lib/telemetry_api_client/pubspec.yaml
+++ b/packages/corbado_api_client/lib/telemetry_api_client/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.0.2
 homepage: https://docs.corbado.com/overview/welcome
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/corbado_api_client/pubspec.yaml
+++ b/packages/corbado_api_client/pubspec.yaml
@@ -6,8 +6,8 @@ version: 1.1.1
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/corbado_auth/example/pubspec.yaml
+++ b/packages/corbado_auth/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: 3.32.0
+  flutter: ">=3.32.0"
 
 dependencies:
   corbado_auth:

--- a/packages/corbado_auth/example/pubspec.yaml
+++ b/packages/corbado_auth/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: 3.10.0
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: 3.32.0
 
 dependencies:
   corbado_auth:

--- a/packages/corbado_auth/pubspec.yaml
+++ b/packages/corbado_auth/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/corba
 version: 3.7.1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   built_collection: ^5.1.1

--- a/packages/corbado_auth_firebase/example/pubspec.yaml
+++ b/packages/corbado_auth_firebase/example/pubspec.yaml
@@ -6,6 +6,7 @@ version: 1.0.0+1
 
 environment:
   sdk: '>=3.8.0 <4.0.0'
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/corbado_auth_firebase/example/pubspec.yaml
+++ b/packages/corbado_auth_firebase/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.2.3 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/corbado_auth_firebase/pubspec.yaml
+++ b/packages/corbado_auth_firebase/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/corba
 version: 2.0.5
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   cloud_functions: ^4.5.8

--- a/packages/passkeys/passkeys/README.md
+++ b/packages/passkeys/passkeys/README.md
@@ -349,7 +349,7 @@ You can also take a look at this package's example to see how it is done there.
 
 #### Requirements
 
-- This package requires Flutter 3.19.0 or later.
+- This package requires Dart 3.8.0 / Flutter 3.32.0 or later.
 
 #### Additional Details
 

--- a/packages/passkeys/passkeys/example/pubspec.yaml
+++ b/packages/passkeys/passkeys/example/pubspec.yaml
@@ -5,6 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/passkeys/passkeys/example/pubspec.yaml
+++ b/packages/passkeys/passkeys/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/passkeys/passkeys/pubspec.yaml
+++ b/packages/passkeys/passkeys/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 2.20.0
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 flutter:
   plugin:

--- a/packages/passkeys/passkeys_android/pubspec.yaml
+++ b/packages/passkeys/passkeys_android/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 2.12.0
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 flutter:
   plugin:

--- a/packages/passkeys/passkeys_darwin/pubspec.yaml
+++ b/packages/passkeys/passkeys_darwin/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 0.4.0
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 flutter:
   plugin:

--- a/packages/passkeys/passkeys_doctor/pubspec.yaml
+++ b/packages/passkeys/passkeys_doctor/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 1.4.1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/passkeys/passkeys_platform_interface/pubspec.yaml
+++ b/packages/passkeys/passkeys_platform_interface/pubspec.yaml
@@ -6,6 +6,7 @@ version: 2.6.0
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/passkeys/passkeys_platform_interface/pubspec.yaml
+++ b/packages/passkeys/passkeys_platform_interface/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 2.6.0
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/passkeys/passkeys_web/pubspec.yaml
+++ b/packages/passkeys/passkeys_web/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 2.9.0
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 flutter:
   plugin:

--- a/packages/passkeys/passkeys_windows/pubspec.yaml
+++ b/packages/passkeys/passkeys_windows/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passk
 version: 0.1.1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_passkeys_workspace
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dev_dependencies:
   melos: ^4.1.0


### PR DESCRIPTION
## What

- Raise the minimum Dart SDK from `3.0.0`/`3.4.0` to `>=3.8.0 <4.0.0` in every package (and align the Flutter constraint to `>=3.32.0`, the release that ships Dart 3.8.0).
- Bump the Flutter version used by the deploy workflows from `3.27.4` to `3.32.0`.

## Why

The `json_serializable` / `json_annotation` versions these packages use require Dart 3.8.0. With the previous `>=3.0.0` floors, the declared SDK range did not match what the code generation toolchain actually needs.

## json constraints are intentionally left unchanged

`json_serializable` (`^6.7.0` / `^6.11.1`, dev) and `json_annotation` (`^4.8.1`, runtime) are **not** bumped. The newest releases (json_serializable 6.14.0, json_annotation 4.12.0) require Dart **3.9.0**. By keeping the existing caret constraints and setting the floor to 3.8.0, pub's SDK-aware resolution gives consumers on Dart 3.8.0 the highest 3.8-compatible json versions (≈ json_serializable 6.12.x, json_annotation 4.10.x), so **consumers are held at 3.8.0 rather than being pushed to 3.9.0**. Consumers on 3.9.0+ still get the newest versions.

## Consumer impact

Because `passkeys` depends on all of its platform implementations (including `passkeys_web`) as regular dependencies, the highest SDK floor in the tree applies to every consumer of `passkeys` on all platforms. This change therefore raises the effective minimum to Dart 3.8.0 for all consumers, which is intentional.

## Note

The `ci.yml` workflow's Flutter version is bumped on the [#249](https://github.com/corbado/flutter-passkeys/pull/249) branch, since that file is introduced there and does not yet exist on `main`.

Versions and CHANGELOGs are left to the Melos release tooling.