### PR TITLE
fix(passkeys_platform_interface): default optional authenticatorSelection fields

### DIFF
--- a/packages/passkeys/passkeys_platform_interface/lib/types/authenticator_selection.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/authenticator_selection.dart
@@ -17,9 +17,28 @@ class AuthenticatorSelectionType {
 
   @JsonKey(includeIfNull: false)
   final String? authenticatorAttachment;
+
+  /// Optional in the WebAuthn spec; defaults to `false` when omitted or null.
+  @JsonKey(defaultValue: false)
   final bool requireResidentKey;
+
+  /// Optional in the WebAuthn spec with no static default; when omitted or null
+  /// its effective value is derived from [requireResidentKey] (`'required'`
+  /// when true, otherwise `'discouraged'`) per WebAuthn Level 3 §5.4.4.
+  @JsonKey(readValue: _readResidentKey)
   final String residentKey;
+
+  /// Optional in the WebAuthn spec; defaults to `'preferred'` when omitted or
+  /// null.
+  @JsonKey(defaultValue: 'preferred')
   final String userVerification;
 
   Map<String, dynamic> toJson() => _$AuthenticatorSelectionTypeToJson(this);
+}
+
+Object? _readResidentKey(Map<dynamic, dynamic> json, String key) {
+  final value = json[key];
+  if (value != null) return value;
+  final requireResidentKey = json['requireResidentKey'] as bool? ?? false;
+  return requireResidentKey ? 'required' : 'discouraged';
 }

--- a/packages/passkeys/passkeys_platform_interface/lib/types/authenticator_selection.g.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/authenticator_selection.g.dart
@@ -10,9 +10,9 @@ AuthenticatorSelectionType _$AuthenticatorSelectionTypeFromJson(
         Map<String, dynamic> json) =>
     AuthenticatorSelectionType(
       authenticatorAttachment: json['authenticatorAttachment'] as String?,
-      requireResidentKey: json['requireResidentKey'] as bool,
-      residentKey: json['residentKey'] as String,
-      userVerification: json['userVerification'] as String,
+      requireResidentKey: json['requireResidentKey'] as bool? ?? false,
+      residentKey: _readResidentKey(json, 'residentKey') as String,
+      userVerification: json['userVerification'] as String? ?? 'preferred',
     );
 
 Map<String, dynamic> _$AuthenticatorSelectionTypeToJson(

--- a/packages/passkeys/passkeys_platform_interface/test/passkeys_platform_interface_test.dart
+++ b/packages/passkeys/passkeys_platform_interface/test/passkeys_platform_interface_test.dart
@@ -38,4 +38,64 @@ void main() {
       PasskeysPlatform.instance = passkeysPlatform;
     });
   });
+
+  group('AuthenticatorSelectionType.fromJson', () {
+    test('applies WebAuthn spec defaults when fields are null', () {
+      final selection = AuthenticatorSelectionType.fromJson({
+        'requireResidentKey': null,
+        'residentKey': null,
+        'userVerification': null,
+      });
+
+      expect(selection.requireResidentKey, isFalse);
+      expect(selection.userVerification, 'preferred');
+    });
+
+    test('applies WebAuthn spec defaults when fields are absent', () {
+      final selection =
+          AuthenticatorSelectionType.fromJson(<String, dynamic>{});
+
+      expect(selection.requireResidentKey, isFalse);
+      expect(selection.userVerification, 'preferred');
+    });
+
+    test('derives residentKey as discouraged when requireResidentKey is false',
+        () {
+      final selection = AuthenticatorSelectionType.fromJson({
+        'requireResidentKey': false,
+      });
+
+      expect(selection.residentKey, 'discouraged');
+    });
+
+    test('derives residentKey as required when requireResidentKey is true', () {
+      final selection = AuthenticatorSelectionType.fromJson({
+        'requireResidentKey': true,
+      });
+
+      expect(selection.residentKey, 'required');
+    });
+
+    test('derives residentKey from default requireResidentKey when both absent',
+        () {
+      final selection =
+          AuthenticatorSelectionType.fromJson(<String, dynamic>{});
+
+      expect(selection.residentKey, 'discouraged');
+    });
+
+    test('preserves provided values', () {
+      final selection = AuthenticatorSelectionType.fromJson({
+        'authenticatorAttachment': 'platform',
+        'requireResidentKey': true,
+        'residentKey': 'required',
+        'userVerification': 'required',
+      });
+
+      expect(selection.authenticatorAttachment, 'platform');
+      expect(selection.requireResidentKey, isTrue);
+      expect(selection.residentKey, 'required');
+      expect(selection.userVerification, 'required');
+    });
+  });
 }


### PR DESCRIPTION
## Problem

`AuthenticatorSelectionType.fromJson` casts `requireResidentKey`, `residentKey` and `userVerification` as non-nullable:

```dart
requireResidentKey: json['requireResidentKey'] as bool,
residentKey: json['residentKey'] as String,
userVerification: json['userVerification'] as String,
```

All three are **optional** members of [`AuthenticatorSelectionCriteria`](https://www.w3.org/TR/webauthn-3/#dictionary-authenticatorSelection) in the WebAuthn Level 3 spec. When a relying party omits them or returns them as JSON `null` (Supabase Auth does this, see supabase/supabase-flutter#1484), the cast throws at runtime:

```
TypeError: null is not a subtype of type 'bool'
```

This breaks `registerPasskey()` on web.

Closes #248

## Fix

Apply the spec treatment for the optional members, keeping the fields **non-nullable** (not a breaking change):

| Field | When omitted/null | Source |
|---|---|---|
| `requireResidentKey` | `false` | spec IDL default (`boolean requireResidentKey = false`) |
| `userVerification` | `'preferred'` | spec IDL default (`DOMString userVerification = "preferred"`) |
| `residentKey` | derived: `'required'` if `requireResidentKey` is true, else `'discouraged'` | [§5.4.4](https://www.w3.org/TR/webauthn-3/#dictionary-authenticatorSelection): `residentKey` has no static default, its effective value is derived from `requireResidentKey` |

`requireResidentKey` and `userVerification` use `@JsonKey(defaultValue:)`. `residentKey` cannot be expressed as a static default since it depends on a sibling field, so it uses a `@JsonKey(readValue:)` hook that reads the whole map and applies the spec derivation. The generated `fromJson` is otherwise unchanged.

## Tests

Added tests covering null fields, absent fields, the `residentKey` derivation for both `requireResidentKey` values, and that explicitly provided values are preserved. All pass.