### PR TITLE
docs(passkeys): document Android Digital Asset Links setup

### DIFF
--- a/packages/passkeys/passkeys/README.md
+++ b/packages/passkeys/passkeys/README.md
@@ -235,7 +235,33 @@ The doctor will automatically perform checks and provide feedback through the Pa
 ### Android
 
 <details>
-<summary>1. Make sure that you have logged into a Google account.</summary>
+<summary>1. Configure Digital Asset Links (assetlinks.json)</summary>
+
+- Make sure your relying server serves a valid Digital Asset Links file at `https://<your-domain>/.well-known/assetlinks.json`.
+- The file must include a statement that grants the `delegate_permission/common.get_login_creds` relation to your app, identified by its package name and the SHA-256 fingerprint of its signing certificate (use the fingerprint of every certificate your app is signed with, including the Play Store upload key):
+
+```json
+[
+  {
+    "relation": ["delegate_permission/common.get_login_creds"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.example.yourapp",
+      "sha256_cert_fingerprints": [
+        "AA:BB:CC:..."
+      ]
+    }
+  }
+]
+```
+
+- The relying party id (RPID) you use must match the domain that hosts the `assetlinks.json` file.
+- Ensure the file is hosted without redirects and served with the `application/json` content type.
+
+</details>
+
+<details>
+<summary>2. Make sure that you have logged into a Google account.</summary>
 
 Google backs up all your passkeys so you need to be logged into a Google account to use passkeys.
 If you are not logged in, you will see the following message: "Sign in to your Google Account to
@@ -248,7 +274,7 @@ then on "Sign in to your Google Account".
 </details>
 
 <details>
-<summary>2. Make sure that you have set up a screen lock or biometrics on your device.</summary>
+<summary>3. Make sure that you have set up a screen lock or biometrics on your device.</summary>
 
 If you run the application in an emulator and it says that you can't create a passkey, you have to
 log into your Google account and properly set up a screen lock or biometrics on the device.
@@ -260,7 +286,7 @@ as well as a fingerprint as shown below (PIN is required for fingerprint):
 </details>
 
 <details>
-<summary>3. In case of using an emulator, make sure that is has Play Store support.</summary>
+<summary>4. In case of using an emulator, make sure that is has Play Store support.</summary>
 
 During our implementation and testing, we detected some bugs when using specific API versions /
 devices of Android emulator (physical devices worked at any time though).


### PR DESCRIPTION
## What

Adds an Android **Digital Asset Links (`assetlinks.json`)** setup entry to the `passkeys` package README, under the platform notes in the Troubleshooting section.

## Why

The README documents the relying-party association setup for macOS (Apple App Site Association + Associated Domains) and the web SDK setup for Web, but there is no equivalent for Android. The existing Android section only covers emulator / Google-account troubleshooting, so a developer setting up passkeys on Android has no in-README pointer to hosting `assetlinks.json`, which is required for the platform to associate the app with the relying party.

This came up while integrating `passkeys` into [`supabase_flutter`](https://github.com/supabase/supabase-flutter/pull/1444), where we want to link users to the plugin's own docs for per-platform setup rather than duplicating it downstream.

## How

- Added a `Configure Digital Asset Links (assetlinks.json)` entry as the first item in the Android section, mirroring the existing macOS AASA entry (hosting location, the required statement with package name and signing-certificate SHA-256 fingerprints, RPID matching the host domain, no redirects, `application/json` content type), with an example file.
- Renumbered the existing Android troubleshooting items accordingly.

Docs only, no code changes.
