### PR TITLE
ci: add automated release workflows for pub.dev publishing

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,45 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        description: 'Version as prerelease'
+        required: false
+        default: false
+        type: boolean
+      graduate:
+        description: 'Graduate prereleases to stable'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.27.4"
+          cache: true
+
+      - name: Version packages
+        uses: bluefireteam/melos-action@v3
+        with:
+          run-versioning: ${{ inputs.prerelease == false }}
+          run-versioning-prerelease: ${{ inputs.prerelease == true }}
+          run-versioning-graduate: ${{ inputs.graduate == true }}
+          create-pr: true
+          pr-title: 'chore(release): publish packages'
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,35 @@
+name: Publish Packages
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish-package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.27.4"
+          cache: true
+
+      - name: Publish to pub.dev and create GitHub Release
+        uses: bluefireteam/melos-action@v3
+        with:
+          publish: true
+          create-release: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,45 @@
+name: Create Release Tags
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  create-tags:
+    if: ${{ contains(github.event.head_commit.message, 'chore(release):') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.27.4"
+          cache: true
+
+      - name: Tag packages
+        uses: bluefireteam/melos-action@v3
+        with:
+          tag: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger publish workflows
+        run: |
+          melos exec -c 1 --no-published --no-private --order-dependents -- \
+            gh workflow run release-publish.yml \
+            --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,19 +133,19 @@ Once your PR is open:
 
 
 ## 7. Release Process (For Maintainers)
-This project uses Melos to handle versioning and publishing. Once changes in main are ready to release:
+This project uses Melos together with GitHub Actions to handle versioning and publishing. Once changes in main are ready to release:
 
-1. Pull the latest main branch locally.
-2. For the changed packages, update the version in the `pubspec.yaml` file. The version should follow the [Semantic Versioning](https://semver.org/) guidelines.
-3. Update the `CHANGELOG.md` file with the new version and a list of changes. The changes should be grouped by package and follow the format of the previous entries.
-4. Dry run publish:
-  ```bash
-    melos publish
-   ```
-5. If everything looks good, publish:
-  ```bash
-    melos publish --no-dry-run
-  ```
+1. Run the [`Prepare Release`](../../actions/workflows/release-prepare.yml) workflow via `workflow_dispatch` (`gh workflow run release-prepare.yml`). This bumps versions and updates `CHANGELOG.md` for all changed packages, based on their conventional commit history, and opens a `chore(release): publish packages` pull request.
+   - Use the `prerelease` input to cut a prerelease instead of a stable version.
+   - Use the `graduate` input to graduate existing prereleases to stable.
+2. Review the generated pull request (versions, changelog entries) and merge it into main.
+3. Merging triggers [`Create Release Tags`](../../actions/workflows/release-tag.yml), which tags each changed package and triggers [`Publish Packages`](../../actions/workflows/release-publish.yml) for it.
+4. `Publish Packages` runs `melos publish` for that package (via pub.dev trusted publishing) and creates the matching GitHub release. No local publish steps or stored pub.dev credentials are needed.
+
+You can still dry-run a version bump locally before triggering the workflow:
+```bash
+  melos version --no-changelog
+```
 
 ## 8. Contributing Documentation
 If you’d like to improve or add documentation:


### PR DESCRIPTION
## Summary
- Adds a three-workflow release pipeline modeled on [supabase-flutter's](https://github.com/supabase/supabase-flutter) release process:
  - `release-prepare.yml` (`workflow_dispatch`): bumps versions/changelogs via Melos versioning and opens a `chore(release): publish packages` PR (supports `prerelease` and `graduate` inputs).
  - `release-tag.yml` (push to `main` on a `chore(release):` commit): tags each changed package and triggers `release-publish.yml` per package.
  - `release-publish.yml` (`workflow_dispatch`, triggered per tag): runs `melos publish` via pub.dev trusted publishing and creates the GitHub release.
- Updates `CONTRIBUTING.md` §7 to describe the new automated release process.

## Prerequisites before this can run end to end
- `GITHUB_TOKEN` is used throughout (no GitHub App). If org/repo settings block Actions from opening PRs or pushing tags on `main`, enable "Allow GitHub Actions to create and approve pull requests" or switch to a PAT/App token.
- pub.dev trusted publishing (OIDC) must be configured per package (Admin → Automated publishing → GitHub Actions) for `passkeys`, `passkeys_android`, `passkeys_darwin`, `passkeys_web`, `passkeys_windows`, `passkeys_platform_interface`, `corbado_auth`, and `corbado_auth_firebase` before `release-publish.yml` can publish.

## Test plan
- [ ] Validate YAML syntax (done locally via Ruby's YAML parser)
- [ ] Configure pub.dev trusted publishing for each package
- [ ] Dry-run `release-prepare.yml` on a branch with pending changes and confirm the PR body/versions look right
- [ ] Merge the release PR and confirm `release-tag.yml` tags the right packages and triggers `release-publish.yml` only for changed ones
- [ ] Confirm `release-publish.yml` publishes to pub.dev and creates a GitHub release