### PR TITLE
ci: use latest Flutter version in release workflows

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.4"
           cache: true
 
       - name: Version packages

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.4"
           cache: true
 
       - name: Publish to pub.dev and create GitHub Release

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.4"
           cache: true
 
       - name: Tag packages


### PR DESCRIPTION
## Summary
- Removed the pinned `flutter-version: "3.27.4"` from `release-prepare.yml`, `release-publish.yml`, and `release-tag.yml`
- `subosito/flutter-action@v2` now defaults to the latest stable Flutter version instead of a fixed one

## Test plan
- [ ] Confirm the release workflows run successfully with the default (latest) Flutter version