### PR TITLE
fix(passkeys_windows): prevent host app crash on window close

### DIFF
--- a/packages/passkeys/passkeys_windows/windows/passkeys_windows_plugin.cpp
+++ b/packages/passkeys/passkeys_windows/windows/passkeys_windows_plugin.cpp
@@ -177,9 +177,9 @@ namespace passkeys_windows
         }
 
         WEBAUTHN_CREDENTIAL_LIST exclude_list = {};
+        std::vector<PWEBAUTHN_CREDENTIAL_EX> exclude_ptrs;
         if (!exclude_creds.empty())
         {
-          std::vector<PWEBAUTHN_CREDENTIAL_EX> exclude_ptrs;
           for (auto &cred : exclude_creds)
           {
             exclude_ptrs.push_back(&cred);
@@ -565,7 +565,11 @@ namespace passkeys_windows
 
   PasskeysWindowsPlugin::~PasskeysWindowsPlugin()
   {
-    PasskeysApi::SetUp(registrar_->messenger(), nullptr);
+    // Do not unregister the channels here. Plugin destruction runs inside
+    // FlutterWindowsEngine::Stop(), where the messenger's engine pointer is
+    // already null, so calling PasskeysApi::SetUp(messenger, nullptr) would
+    // dereference null and crash the host app on window close. The engine
+    // tears down the channels itself.
   }
 
   void PasskeysWindowsPlugin::RegisterWithRegistrar(


### PR DESCRIPTION
Fixes #260.

## Bug 1: crash on every window close (use-after-teardown)

`PasskeysWindowsPlugin::~PasskeysWindowsPlugin()` called `PasskeysApi::SetUp(registrar_->messenger(), nullptr)` to unregister its channels. Plugin destruction runs inside `FlutterWindowsEngine::Stop()`, at which point the messenger's engine pointer is already null, so `FlutterDesktopMessengerSetCallback` dereferenced null and the process died with `0xc0000005` on **every** window close, even when the host app never invoked any passkeys API (the plugin registers at startup as a transitive dependency).

Official Flutter plugins don't unregister channels in the destructor, the engine tears them down itself. The destructor is now a no-op.

## Bug 2: use-after-free in `Register()`

`exclude_ptrs` was declared **inside** the `if (!exclude_creds.empty())` block, so `WEBAUTHN_CREDENTIAL_LIST.ppCredentials` pointed at freed memory before `WebAuthNAuthenticatorMakeCredential` ran whenever `excludeCredentials` was non-empty. The vector is now hoisted to the enclosing scope so it outlives the WebAuthn call.

Both fixes were reported and verified locally by @Lufransolutions in #260.