### PR TITLE
ci: validate PR titles follow conventional commits

### DIFF
--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -1,4 +1,3 @@
-# See https://github.com/amannn/action-semantic-pull-request
 name: 'PR Title is Conventional'
 
 on:

--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -1,0 +1,33 @@
+# See https://github.com/amannn/action-semantic-pull-request
+name: 'PR Title is Conventional'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.


### PR DESCRIPTION
Adds a workflow that validates pull request titles follow the [Conventional Commits](https://www.conventionalcommits.org/) spec, mirroring the setup in the `supabase-flutter` repo.

This is enforced via [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request), running on PR open/edit/synchronize. It also rejects subjects that start with an uppercase character.

This matches the existing PR title convention documented in `CLAUDE.md` (e.g. `fix(passkeys_android): fixed a bug!`).