### PR TITLE
ci: add build verification for all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,63 @@ jobs:
 
       - name: Test
         run: melos run test
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: analyze-and-test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Android
+            os: ubuntu-latest
+            build: flutter build apk --debug
+          - name: Web
+            os: ubuntu-latest
+            build: flutter build web
+          - name: Windows
+            os: windows-latest
+            build: flutter build windows --debug
+          - name: macOS
+            os: macos-latest
+            build: flutter build macos --debug
+          - name: iOS (Swift Package Manager)
+            os: macos-latest
+            swift-package-manager: true
+            build: flutter build ios --debug --no-codesign
+          - name: iOS (CocoaPods)
+            os: macos-latest
+            swift-package-manager: false
+            build: flutter build ios --debug --no-codesign
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Java
+        if: matrix.name == 'Android'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.32.0"
+
+      - name: Set up melos
+        uses: bluefireteam/melos-action@v3
+
+      - name: Enable Swift Package Manager
+        if: matrix.swift-package-manager == true
+        run: flutter config --enable-swift-package-manager
+
+      - name: Disable Swift Package Manager
+        if: matrix.swift-package-manager == false
+        run: flutter config --no-enable-swift-package-manager
+
+      - name: Build
+        working-directory: packages/passkeys/passkeys/example
+        run: ${{ matrix.build }}


### PR DESCRIPTION
## What

Adds a `build` job to the CI pipeline that verifies the `passkeys` example compiles on every supported platform after analyze-and-test passes.

## Coverage

Matrix build (`fail-fast: false`):

| Platform | Runner | Build |
|---|---|---|
| Android | ubuntu-latest | `flutter build apk --debug` (Temurin JDK 17) |
| Web | ubuntu-latest | `flutter build web` |
| Windows | windows-latest | `flutter build windows --debug` |
| macOS | macos-latest | `flutter build macos --debug` |
| iOS (Swift Package Manager) | macos-latest | `flutter build ios --debug --no-codesign` |
| iOS (CocoaPods) | macos-latest | `flutter build ios --debug --no-codesign` |

## Notes

- The `passkeys` example is the target because it's the only example shipping all five platform folders, so building it exercises the native plugin code (`passkeys_android`, `passkeys_darwin`, `passkeys_web`, `passkeys_windows`) on each OS.
- iOS is split into two entries to cover the `passkeys_darwin` dual-build: one enables SwiftPM, the other forces CocoaPods (`--no-enable-swift-package-manager`).
- `melos bootstrap` runs first so the example resolves local sibling packages via pubspec overrides.