### PR TITLE
fix(passkeys_darwin): map no-credentials-available regardless of device locale

### DIFF
--- a/packages/passkeys/passkeys/test/authenticator_test.dart
+++ b/packages/passkeys/passkeys/test/authenticator_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:passkeys/authenticator.dart';
+import 'package:passkeys/exceptions.dart';
+import 'package:passkeys_platform_interface/passkeys_platform_interface.dart';
+import 'package:passkeys_platform_interface/types/types.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class _ThrowingPlatform extends PasskeysPlatform
+    with MockPlatformInterfaceMixin {
+  _ThrowingPlatform(this.exception);
+
+  final PlatformException exception;
+
+  @override
+  Future<void> cancelCurrentAuthenticatorOperation() async {}
+
+  @override
+  Future<RegisterResponseType> register(RegisterRequestType request) async {
+    throw exception;
+  }
+
+  @override
+  Future<AuthenticateResponseType> authenticate(
+    AuthenticateRequestType request,
+  ) async {
+    throw exception;
+  }
+
+  @override
+  Future<AvailabilityType> getAvailability() {
+    throw UnimplementedError();
+  }
+}
+
+AuthenticateRequestType _authenticateRequest() => const AuthenticateRequestType(
+  relyingPartyId: 'example.com',
+  challenge: 'Y2hhbGxlbmdl',
+  mediation: MediationType.Optional,
+  preferImmediatelyAvailableCredentials: true,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('authenticate maps platform error codes to typed exceptions', () {
+    Future<void> expectMapping(
+      String code,
+      Matcher matcher, {
+      String? message,
+    }) async {
+      PasskeysPlatform.instance = _ThrowingPlatform(
+        PlatformException(code: code, message: message),
+      );
+      final authenticator = PasskeyAuthenticator();
+
+      await expectLater(
+        () => authenticator.authenticate(_authenticateRequest()),
+        throwsA(matcher),
+      );
+    }
+
+    // Regression test for
+    // https://github.com/corbado/flutter-passkeys/issues/262 (duplicate of
+    // #236). On non-English devices the native layer now surfaces
+    // `no-credentials-available` for the "no passkeys on device" case
+    // instead of `cancelled`, so it must not be mapped to
+    // PasskeyAuthCancelledException.
+    test(
+      'no-credentials-available throws NoCredentialsAvailableException',
+      () async {
+        await expectMapping(
+          'no-credentials-available',
+          isA<NoCredentialsAvailableException>(),
+        );
+      },
+    );
+
+    test('cancelled still throws PasskeyAuthCancelledException', () async {
+      await expectMapping('cancelled', isA<PasskeyAuthCancelledException>());
+    });
+
+    test('domain-not-associated throws DomainNotAssociatedException', () async {
+      await expectMapping(
+        'domain-not-associated',
+        isA<DomainNotAssociatedException>(),
+      );
+    });
+  });
+}

--- a/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/AuthenticateController.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/AuthenticateController.swift
@@ -95,6 +95,7 @@ class AuthenticateController: NSObject, ASAuthorizationControllerDelegate, ASAut
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         if let err = error as? ASAuthorizationError {
             completion?(.failure(FlutterError(from: err)))
+            return
         }
 
         let nsErr = error as NSError

--- a/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/ErrorExtension.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/ErrorExtension.swift
@@ -18,7 +18,13 @@ extension FlutterError: Error {
             code = "unknown"
             break
         case ASAuthorizationError.canceled:
-            if (error.localizedDescription.contains("No credentials available for login.")) {
+            // Apple returns `.canceled` both when the user dismisses the sheet
+            // and when there are no credentials available, and intentionally
+            // exposes no locale independent way to tell them apart in the modal
+            // flow. `preferImmediatelyAvailableCredentials` avoids this ambiguity
+            // by surfacing `.notInteractive` instead (handled below). As a best
+            // effort for the modal flow we still inspect the error strings.
+            if (isNoCredentialsAvailable(error)) {
                 code = "no-credentials-available"
             } else {
                 code = "cancelled"
@@ -38,9 +44,16 @@ extension FlutterError: Error {
             }
             break
         default:
+            // ASAuthorizationError code 1005 (.notInteractive, iOS 15+) is returned
+            // when `preferImmediatelyAvailableCredentials` is set and no credentials
+            // are available, without showing any UI. This is the only reliable,
+            // locale independent signal for the no credentials case.
+            if error.code.rawValue == 1005 {
+                code = "no-credentials-available"
+            }
             // ASAuthorizationError code 1006 (.matchedExcludedCredential, iOS 18+)
             // indicates the device already holds a credential listed in excludeCredentials.
-            if error.code.rawValue == 1006 {
+            else if error.code.rawValue == 1006 {
                 code = "exclude-credentials-match"
             } else {
                 code = "unknown"
@@ -68,6 +81,21 @@ extension FlutterError: Error {
     convenience init(code: CustomErrors, message: String = "") {
         self.init(code: String(describing: code), message: message, details: "")
     }
+}
+
+@available(iOS 13.0, *)
+private func isNoCredentialsAvailable(_ error: ASAuthorizationError) -> Bool {
+    let nsError = error as NSError
+    let candidates = [
+        error.localizedDescription,
+        nsError.userInfo[NSLocalizedFailureReasonErrorKey] as? String,
+        nsError.userInfo[NSDebugDescriptionErrorKey] as? String,
+        (nsError.userInfo[NSUnderlyingErrorKey] as? NSError)?.localizedDescription,
+    ]
+
+    return candidates
+        .compactMap { $0 }
+        .contains { $0.contains("No credentials available for login.") }
 }
 
 enum CustomErrors: Error {


### PR DESCRIPTION
## Summary

On iOS, calling `authenticate` when the device has no passkeys threw `PasskeyAuthCancelledException` instead of `NoCredentialsAvailableException` on non-English devices, so apps could not tell "no credentials" apart from a real user cancel. Fixes #236 (and the #262 duplicate).

### Root cause

`ErrorExtension.swift` decided between the two by matching the **English** substring `"No credentials available for login."` against `localizedDescription`. On a Chinese device that string is localized (`没有可用于登录的凭证。`), the match fails, and it falls through to `cancelled`.

In the standard modal flow iOS returns `ASAuthorizationError.canceled` (1001) for **both** user-cancel and no-credentials, and [intentionally exposes no locale-independent way](https://developer.apple.com/forums/thread/735867) to distinguish them (a privacy design). The one reliable signal is `.notInteractive` (1005), returned when `preferImmediatelyAvailableCredentials` is set and no credentials exist. That flag already defaults to `true` in `AuthenticateRequest`.

## Changes

- Map `ASAuthorizationError.notInteractive` (code 1005) → `no-credentials-available`. Previously unmapped (fell through to `unknown`). Handled via `error.code.rawValue == 1005` in the `default` branch, mirroring the existing 1006 handling, to avoid an `@available` issue (`.notInteractive` is iOS 15+, the extension targets iOS 13+).
- Broaden the modal-flow heuristic into `isNoCredentialsAvailable(_:)`, which also inspects `NSLocalizedFailureReason`, `NSDebugDescription`, and any underlying error, not just `localizedDescription`.
- Return after handling `ASAuthorizationError` in `AuthenticateController.didCompleteWithError` so `completion` is not invoked a second time with the wrongly-mapped `NSError` fallback (`RegisterController` already did this).

The Dart layer already routes `no-credentials-available` → `NoCredentialsAvailableException`, so no Dart change is needed.

## Notes

- Change to `.notInteractive` mapping is a reliable improvement. The broadened string heuristic is best-effort; consumers who explicitly set `preferImmediatelyAvailableCredentials: false` still hit the platform-level ambiguity Apple does not let us resolve.
- Scoped to `passkeys_darwin` Swift source only, no path/manifest changes, so both the SwiftPM and CocoaPods builds are unaffected.

## Testing

Not yet verified on-device. Recommend confirming on a non-English locale (e.g. Chinese) with no passkeys registered that `authenticate` now throws `NoCredentialsAvailableException`.