### PR TITLE
fix(passkeys_android): downgrade expected auth errors from Log.e to Log.d

### DIFF
--- a/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
+++ b/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
@@ -337,18 +337,20 @@ public class MessageHandler implements Messages.PasskeysApi {
                         @Override
                         public void onError(GetCredentialException e) {
                             Exception platformException = e;
-                            Log.e(TAG, "onError called", e);
 
                             // currently, Android throws this error when users skip the fingerPrint
                             // animation => we interpret this as a cancellation for now
                             if (Objects.equals(e.getMessage(),
                                     "None of the allowed credentials can be authenticated")) {
                                 platformException = new Messages.FlutterError("cancelled", e.getMessage(), "");
+                                Log.d(TAG, "onError called", e);
                             } else if (e instanceof GetCredentialCancellationException) {
                                 platformException = new Messages.FlutterError("cancelled", e.getMessage(), "");
+                                Log.d(TAG, "onError called", e);
                             } else if (e instanceof NoCredentialException) {
                                 platformException = new Messages.FlutterError("android-no-credential", e.getMessage(),
                                         "");
+                                Log.d(TAG, "onError called", e);
                             } else if (e instanceof GetPublicKeyCredentialDomException) {
                                 if (Objects.equals(e.getMessage(), "Failed to decrypt credential.")) {
                                     platformException = new Messages.FlutterError("android-sync-account-not-available",
@@ -360,9 +362,11 @@ public class MessageHandler implements Messages.PasskeysApi {
                                     platformException = new Messages.FlutterError("android-unhandled: " + e.getType(),
                                             e.getMessage(), e.getErrorMessage());
                                 }
+                                Log.e(TAG, "onError called", e);
                             } else {
                                 platformException = new Messages.FlutterError("android-unhandled: " + e.getType(),
                                         e.getMessage(), e.getErrorMessage());
+                                Log.e(TAG, "onError called", e);
                             }
 
                             result.error(platformException);


### PR DESCRIPTION
## Problem

Closes #223

During conditional UI login, the authenticate `onError` callback logged **every** error at error level with a full stack trace, before the exception was classified:

```java
Log.e(TAG, "onError called", e);
```

This meant expected outcomes like `NoCredentialException` ("Cannot find a matching credential") and user cancellations dumped noisy error-level stack traces to logcat, even when the caller supplied an `onError` handler to ignore them.

## Fix

Removed the unconditional `Log.e` and moved logging into each classification branch:

- **Expected outcomes** → `Log.d` (only visible during development): "None of the allowed credentials can be authenticated", `GetCredentialCancellationException`, and `NoCredentialException`.
- **Genuinely unexpected errors** → `Log.e` retained: unhandled DOM exceptions and the catch-all branch.

The registration flow's `onError` had no unconditional log, so it was left unchanged.