### PR TITLE
feat(passkeys_web): add PRF extension support

### DIFF
--- a/packages/passkeys/passkeys/example/web/bundle.js
+++ b/packages/passkeys/passkeys/example/web/bundle.js
@@ -218,12 +218,6 @@ var PasskeyAuthenticator = (function (exports) {
         credential
       );
     }
-    async function create(requestJSON) {
-      const credential = await navigator.credentials.create(
-        createRequestFromJSON(requestJSON)
-      );
-      return createResponseToJSON(credential);
-    }
     function getRequestFromJSON(requestJSON) {
       return convert(base64urlToBuffer, credentialRequestOptions, requestJSON);
     }
@@ -234,12 +228,53 @@ var PasskeyAuthenticator = (function (exports) {
         credential
       );
     }
-    async function get(requestJSON) {
-      const credential = await navigator.credentials.get(
-        getRequestFromJSON(requestJSON)
-      );
-      return getResponseToJSON(credential);
-    }
+
+    // src/webauthn-json/extended/schema.ts
+    var authenticationExtensionsClientInputsSchema = {
+      appid: optional(copyValue),
+      appidExclude: optional(copyValue),
+      uvm: optional(copyValue),
+      credProps: optional(copyValue),
+      largeBlob: optional({
+        support: optional(copyValue),
+        read: optional(copyValue),
+        write: optional(convertValue)
+      })
+    };
+    var authenticationExtensionsClientOutputsSchema = {
+      appid: optional(copyValue),
+      appidExclude: optional(copyValue),
+      uvm: optional(copyValue),
+      credProps: optional(copyValue),
+      largeBlob: optional({
+        supported: optional(copyValue),
+        blob: optional(convertValue),
+        written: optional(copyValue)
+      })
+    };
+    var credentialCreationOptionsExtended = JSON.parse(
+      JSON.stringify(credentialCreationOptions)
+    );
+    credentialCreationOptionsExtended.publicKey.schema.extensions = optional(authenticationExtensionsClientInputsSchema);
+    var publicKeyCredentialWithAttestationExtended = JSON.parse(
+      JSON.stringify(publicKeyCredentialWithAttestation)
+    );
+    publicKeyCredentialWithAttestationExtended.clientExtensionResults = derived(
+      authenticationExtensionsClientOutputsSchema,
+      publicKeyCredentialWithAttestation.clientExtensionResults.derive
+    );
+    publicKeyCredentialWithAttestationExtended.response.schema.transports = publicKeyCredentialWithAttestation.response.schema.transports;
+    var credentialRequestOptionsExtended = JSON.parse(
+      JSON.stringify(credentialRequestOptions)
+    );
+    credentialRequestOptionsExtended.publicKey.schema.extensions = optional(authenticationExtensionsClientInputsSchema);
+    var publicKeyCredentialWithAssertionExtended = JSON.parse(
+      JSON.stringify(publicKeyCredentialWithAssertion)
+    );
+    publicKeyCredentialWithAssertionExtended.clientExtensionResults = derived(
+      authenticationExtensionsClientOutputsSchema,
+      publicKeyCredentialWithAssertion.clientExtensionResults.derive
+    );
 
     var _PasskeyAuthenticator_abortController;
     const ABORTED_BY_USER = 'operation aborted by user.';
@@ -248,10 +283,14 @@ var PasskeyAuthenticator = (function (exports) {
             _PasskeyAuthenticator_abortController.set(this, undefined);
         }
         async register(params) {
+            var _a;
             try {
                 const typedParams = JSON.parse(params);
-                const out = await create(typedParams);
-                return JSON.stringify(out);
+                const request = createRequestFromJSON(typedParams);
+                applyPrfInput(request.publicKey, (_a = typedParams.publicKey) === null || _a === void 0 ? void 0 : _a.extensions);
+                const credential = await navigator.credentials.create(request);
+                const out = createResponseToJSON(credential);
+                return JSON.stringify(withPrfResults(out, credential));
             }
             catch (e) {
                 let error;
@@ -270,12 +309,16 @@ var PasskeyAuthenticator = (function (exports) {
             }
         }
         async login(params) {
+            var _a;
             try {
                 __classPrivateFieldSet(this, _PasskeyAuthenticator_abortController, new AbortController(), "f");
                 const typedParams = JSON.parse(params);
                 typedParams.signal = __classPrivateFieldGet(this, _PasskeyAuthenticator_abortController, "f").signal;
-                const out = await get(typedParams);
-                return JSON.stringify(out);
+                const request = getRequestFromJSON(typedParams);
+                applyPrfInput(request.publicKey, (_a = typedParams.publicKey) === null || _a === void 0 ? void 0 : _a.extensions);
+                const credential = await navigator.credentials.get(request);
+                const out = getResponseToJSON(credential);
+                return JSON.stringify(withPrfResults(out, credential));
             }
             catch (e) {
                 let error;
@@ -303,6 +346,42 @@ var PasskeyAuthenticator = (function (exports) {
         }
     }
     _PasskeyAuthenticator_abortController = new WeakMap();
+    // The @github/webauthn-json schema does not know about the PRF extension, so
+    // it drops the salts on the way in and the results on the way out. We convert
+    // those base64url values ourselves and splice them back in.
+    function applyPrfInput(publicKey, extensions) {
+        var _a;
+        const evalInput = (_a = extensions === null || extensions === undefined ? undefined : extensions.prf) === null || _a === undefined ? undefined : _a.eval;
+        if (!evalInput) {
+            return;
+        }
+        const prf = {
+            eval: { first: base64urlToBuffer(evalInput.first) },
+        };
+        if (evalInput.second) {
+            prf.eval.second = base64urlToBuffer(evalInput.second);
+        }
+        publicKey.extensions = { ...(publicKey.extensions || {}), prf };
+    }
+    function withPrfResults(out, credential) {
+        var _a, _b;
+        const prf = (_a = credential.getClientExtensionResults()) === null || _a === undefined ? undefined : _a.prf;
+        if (!prf) {
+            return out;
+        }
+        const prfJson = {};
+        if (typeof prf.enabled === 'boolean') {
+            prfJson.enabled = prf.enabled;
+        }
+        if ((_b = prf.results) === null || _b === undefined ? undefined : _b.first) {
+            prfJson.results = { first: bufferToBase64url(prf.results.first) };
+            if (prf.results.second) {
+                prfJson.results.second = bufferToBase64url(prf.results.second);
+            }
+        }
+        out.clientExtensionResults = { ...(out.clientExtensionResults || {}), prf: prfJson };
+        return out;
+    }
     class PlatformError {
         constructor(code, message, details) {
             this.code = code;

--- a/packages/passkeys/passkeys/example/web/bundle.js
+++ b/packages/passkeys/passkeys/example/web/bundle.js
@@ -36,245 +36,185 @@ var PasskeyAuthenticator = (function (exports) {
         return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
     };
 
-    // src/webauthn-json/base64url.ts
     function base64urlToBuffer(baseurl64String) {
-      const padding = "==".slice(0, (4 - baseurl64String.length % 4) % 4);
-      const base64String = baseurl64String.replace(/-/g, "+").replace(/_/g, "/") + padding;
-      const str = atob(base64String);
-      const buffer = new ArrayBuffer(str.length);
-      const byteView = new Uint8Array(buffer);
-      for (let i = 0; i < str.length; i++) {
-        byteView[i] = str.charCodeAt(i);
-      }
-      return buffer;
+        // Base64url to Base64
+        const padding = "==".slice(0, (4 - (baseurl64String.length % 4)) % 4);
+        const base64String = baseurl64String.replace(/-/g, "+").replace(/_/g, "/") + padding;
+        // Base64 to binary string
+        const str = atob(base64String);
+        // Binary string to buffer
+        const buffer = new ArrayBuffer(str.length);
+        const byteView = new Uint8Array(buffer);
+        for (let i = 0; i < str.length; i++) {
+            byteView[i] = str.charCodeAt(i);
+        }
+        return buffer;
     }
     function bufferToBase64url(buffer) {
-      const byteView = new Uint8Array(buffer);
-      let str = "";
-      for (const charCode of byteView) {
-        str += String.fromCharCode(charCode);
-      }
-      const base64String = btoa(str);
-      const base64urlString = base64String.replace(/\+/g, "-").replace(
-        /\//g,
-        "_"
-      ).replace(/=/g, "");
-      return base64urlString;
-    }
-
-    // src/webauthn-json/convert.ts
-    var copyValue = "copy";
-    var convertValue = "convert";
-    function convert(conversionFn, schema2, input) {
-      if (schema2 === copyValue) {
-        return input;
-      }
-      if (schema2 === convertValue) {
-        return conversionFn(input);
-      }
-      if (schema2 instanceof Array) {
-        return input.map((v) => convert(conversionFn, schema2[0], v));
-      }
-      if (schema2 instanceof Object) {
-        const output = {};
-        for (const [key, schemaField] of Object.entries(schema2)) {
-          if (schemaField.derive) {
-            const v = schemaField.derive(input);
-            if (v !== undefined) {
-              input[key] = v;
-            }
-          }
-          if (!(key in input)) {
-            if (schemaField.required) {
-              throw new Error(`Missing key: ${key}`);
-            }
-            continue;
-          }
-          if (input[key] == null) {
-            output[key] = null;
-            continue;
-          }
-          output[key] = convert(
-            conversionFn,
-            schemaField.schema,
-            input[key]
-          );
+        // Buffer to binary string
+        const byteView = new Uint8Array(buffer);
+        let str = "";
+        for (const charCode of byteView) {
+            str += String.fromCharCode(charCode);
         }
-        return output;
-      }
-    }
-    function derived(schema2, derive) {
-      return {
-        required: true,
-        schema: schema2,
-        derive
-      };
-    }
-    function required(schema2) {
-      return {
-        required: true,
-        schema: schema2
-      };
-    }
-    function optional(schema2) {
-      return {
-        required: false,
-        schema: schema2
-      };
+        // Binary string to base64
+        const base64String = btoa(str);
+        // Base64 to base64url
+        // We assume that the base64url string is well-formed.
+        const base64urlString = base64String.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+        return base64urlString;
     }
 
-    // src/webauthn-json/basic/schema.ts
-    var publicKeyCredentialDescriptorSchema = {
-      type: required(copyValue),
-      id: required(convertValue),
-      transports: optional(copyValue)
+    // We export these values in order so that they can be used to deduplicate
+    // schema definitions in minified JS code.
+    // TODO: Parcel isn't deduplicating these values.
+    const copyValue = "copy";
+    const convertValue = "convert";
+    function convert(conversionFn, schema, input) {
+        if (schema === copyValue) {
+            return input;
+        }
+        if (schema === convertValue) {
+            return conversionFn(input);
+        }
+        if (schema instanceof Array) {
+            return input.map((v) => convert(conversionFn, schema[0], v));
+        }
+        if (schema instanceof Object) {
+            const output = {};
+            for (const [key, schemaField] of Object.entries(schema)) {
+                if (schemaField.derive) {
+                    const v = schemaField.derive(input);
+                    if (v !== undefined) {
+                        input[key] = v;
+                    }
+                }
+                if (!(key in input)) {
+                    if (schemaField.required) {
+                        throw new Error(`Missing key: ${key}`);
+                    }
+                    continue;
+                }
+                // Fields can be null (rather than missing or `undefined`), e.g. the
+                // `userHandle` field of the `AuthenticatorAssertionResponse`:
+                // https://www.w3.org/TR/webauthn/#iface-authenticatorassertionresponse
+                if (input[key] == null) {
+                    output[key] = null;
+                    continue;
+                }
+                output[key] = convert(conversionFn, schemaField.schema, input[key]);
+            }
+            return output;
+        }
+    }
+    function derived(schema, derive) {
+        return {
+            required: true,
+            schema,
+            derive,
+        };
+    }
+    function required(schema) {
+        return {
+            required: true,
+            schema,
+        };
+    }
+    function optional(schema) {
+        return {
+            required: false,
+            schema,
+        };
+    }
+
+    // Shared by `create()` and `get()`.
+    const publicKeyCredentialDescriptorSchema = {
+        type: required(copyValue),
+        id: required(convertValue),
+        transports: optional(copyValue),
     };
-    var simplifiedExtensionsSchema = {
-      appid: optional(copyValue),
-      appidExclude: optional(copyValue),
-      credProps: optional(copyValue)
+    const simplifiedExtensionsSchema = {
+        appid: optional(copyValue),
+        appidExclude: optional(copyValue),
+        credProps: optional(copyValue),
     };
-    var simplifiedClientExtensionResultsSchema = {
-      appid: optional(copyValue),
-      appidExclude: optional(copyValue),
-      credProps: optional(copyValue)
+    const simplifiedClientExtensionResultsSchema = {
+        appid: optional(copyValue),
+        appidExclude: optional(copyValue),
+        credProps: optional(copyValue),
     };
-    var credentialCreationOptions = {
-      publicKey: required({
-        rp: required(copyValue),
-        user: required({
-          id: required(convertValue),
-          name: required(copyValue),
-          displayName: required(copyValue)
+    // `navigator.create()` request
+    const credentialCreationOptions = {
+        publicKey: required({
+            rp: required(copyValue),
+            user: required({
+                id: required(convertValue),
+                name: required(copyValue),
+                displayName: required(copyValue),
+            }),
+            challenge: required(convertValue),
+            pubKeyCredParams: required(copyValue),
+            timeout: optional(copyValue),
+            excludeCredentials: optional([publicKeyCredentialDescriptorSchema]),
+            authenticatorSelection: optional(copyValue),
+            attestation: optional(copyValue),
+            extensions: optional(simplifiedExtensionsSchema),
         }),
-        challenge: required(convertValue),
-        pubKeyCredParams: required(copyValue),
-        timeout: optional(copyValue),
-        excludeCredentials: optional([publicKeyCredentialDescriptorSchema]),
-        authenticatorSelection: optional(copyValue),
-        attestation: optional(copyValue),
-        extensions: optional(simplifiedExtensionsSchema)
-      }),
-      signal: optional(copyValue)
+        signal: optional(copyValue),
     };
-    var publicKeyCredentialWithAttestation = {
-      type: required(copyValue),
-      id: required(copyValue),
-      rawId: required(convertValue),
-      authenticatorAttachment: optional(copyValue),
-      response: required({
-        clientDataJSON: required(convertValue),
-        attestationObject: required(convertValue),
-        transports: derived(
-          copyValue,
-          (response) => {
-            var _a;
-            return ((_a = response.getTransports) == null ? undefined : _a.call(response)) || [];
-          }
-        )
-      }),
-      clientExtensionResults: derived(
-        simplifiedClientExtensionResultsSchema,
-        (pkc) => pkc.getClientExtensionResults()
-      )
+    // `navigator.create()` response
+    const publicKeyCredentialWithAttestation = {
+        type: required(copyValue),
+        id: required(copyValue),
+        rawId: required(convertValue),
+        authenticatorAttachment: optional(copyValue),
+        response: required({
+            clientDataJSON: required(convertValue),
+            attestationObject: required(convertValue),
+            transports: derived(copyValue, (response) => { var _a; return ((_a = response.getTransports) === null || _a === undefined ? undefined : _a.call(response)) || []; }),
+        }),
+        clientExtensionResults: derived(simplifiedClientExtensionResultsSchema, (pkc) => pkc.getClientExtensionResults()),
     };
-    var credentialRequestOptions = {
-      mediation: optional(copyValue),
-      publicKey: required({
-        challenge: required(convertValue),
-        timeout: optional(copyValue),
-        rpId: optional(copyValue),
-        allowCredentials: optional([publicKeyCredentialDescriptorSchema]),
-        userVerification: optional(copyValue),
-        extensions: optional(simplifiedExtensionsSchema)
-      }),
-      signal: optional(copyValue)
+    // `navigator.get()` request
+    const credentialRequestOptions = {
+        mediation: optional(copyValue),
+        publicKey: required({
+            challenge: required(convertValue),
+            timeout: optional(copyValue),
+            rpId: optional(copyValue),
+            allowCredentials: optional([publicKeyCredentialDescriptorSchema]),
+            userVerification: optional(copyValue),
+            extensions: optional(simplifiedExtensionsSchema),
+        }),
+        signal: optional(copyValue),
     };
-    var publicKeyCredentialWithAssertion = {
-      type: required(copyValue),
-      id: required(copyValue),
-      rawId: required(convertValue),
-      authenticatorAttachment: optional(copyValue),
-      response: required({
-        clientDataJSON: required(convertValue),
-        authenticatorData: required(convertValue),
-        signature: required(convertValue),
-        userHandle: required(convertValue)
-      }),
-      clientExtensionResults: derived(
-        simplifiedClientExtensionResultsSchema,
-        (pkc) => pkc.getClientExtensionResults()
-      )
+    // `navigator.get()` response
+    const publicKeyCredentialWithAssertion = {
+        type: required(copyValue),
+        id: required(copyValue),
+        rawId: required(convertValue),
+        authenticatorAttachment: optional(copyValue),
+        response: required({
+            clientDataJSON: required(convertValue),
+            authenticatorData: required(convertValue),
+            signature: required(convertValue),
+            userHandle: required(convertValue),
+        }),
+        clientExtensionResults: derived(simplifiedClientExtensionResultsSchema, (pkc) => pkc.getClientExtensionResults()),
     };
 
-    // src/webauthn-json/basic/api.ts
     function createRequestFromJSON(requestJSON) {
-      return convert(base64urlToBuffer, credentialCreationOptions, requestJSON);
+        return convert(base64urlToBuffer, credentialCreationOptions, requestJSON);
     }
     function createResponseToJSON(credential) {
-      return convert(
-        bufferToBase64url,
-        publicKeyCredentialWithAttestation,
-        credential
-      );
+        return convert(bufferToBase64url, publicKeyCredentialWithAttestation, credential);
     }
     function getRequestFromJSON(requestJSON) {
-      return convert(base64urlToBuffer, credentialRequestOptions, requestJSON);
+        return convert(base64urlToBuffer, credentialRequestOptions, requestJSON);
     }
     function getResponseToJSON(credential) {
-      return convert(
-        bufferToBase64url,
-        publicKeyCredentialWithAssertion,
-        credential
-      );
+        return convert(bufferToBase64url, publicKeyCredentialWithAssertion, credential);
     }
-
-    // src/webauthn-json/extended/schema.ts
-    var authenticationExtensionsClientInputsSchema = {
-      appid: optional(copyValue),
-      appidExclude: optional(copyValue),
-      uvm: optional(copyValue),
-      credProps: optional(copyValue),
-      largeBlob: optional({
-        support: optional(copyValue),
-        read: optional(copyValue),
-        write: optional(convertValue)
-      })
-    };
-    var authenticationExtensionsClientOutputsSchema = {
-      appid: optional(copyValue),
-      appidExclude: optional(copyValue),
-      uvm: optional(copyValue),
-      credProps: optional(copyValue),
-      largeBlob: optional({
-        supported: optional(copyValue),
-        blob: optional(convertValue),
-        written: optional(copyValue)
-      })
-    };
-    var credentialCreationOptionsExtended = JSON.parse(
-      JSON.stringify(credentialCreationOptions)
-    );
-    credentialCreationOptionsExtended.publicKey.schema.extensions = optional(authenticationExtensionsClientInputsSchema);
-    var publicKeyCredentialWithAttestationExtended = JSON.parse(
-      JSON.stringify(publicKeyCredentialWithAttestation)
-    );
-    publicKeyCredentialWithAttestationExtended.clientExtensionResults = derived(
-      authenticationExtensionsClientOutputsSchema,
-      publicKeyCredentialWithAttestation.clientExtensionResults.derive
-    );
-    publicKeyCredentialWithAttestationExtended.response.schema.transports = publicKeyCredentialWithAttestation.response.schema.transports;
-    var credentialRequestOptionsExtended = JSON.parse(
-      JSON.stringify(credentialRequestOptions)
-    );
-    credentialRequestOptionsExtended.publicKey.schema.extensions = optional(authenticationExtensionsClientInputsSchema);
-    var publicKeyCredentialWithAssertionExtended = JSON.parse(
-      JSON.stringify(publicKeyCredentialWithAssertion)
-    );
-    publicKeyCredentialWithAssertionExtended.clientExtensionResults = derived(
-      authenticationExtensionsClientOutputsSchema,
-      publicKeyCredentialWithAssertion.clientExtensionResults.derive
-    );
 
     var _PasskeyAuthenticator_abortController;
     const ABORTED_BY_USER = 'operation aborted by user.';

--- a/packages/passkeys/passkeys_web/javascript/src/passkeyAuthenticator.ts
+++ b/packages/passkeys/passkeys_web/javascript/src/passkeyAuthenticator.ts
@@ -1,11 +1,16 @@
+// Import the basic request/response conversions and the base64url helpers
+// directly from their modules (rather than the "@github/webauthn-json/extended"
+// aggregate) so the bundle does not pull in the unused extended schema.
 import {
-    base64urlToBuffer,
-    bufferToBase64url,
     createRequestFromJSON,
     createResponseToJSON,
     getRequestFromJSON,
     getResponseToJSON,
-} from "@github/webauthn-json/extended";
+} from "@github/webauthn-json/src/webauthn-json/basic/api";
+import {
+    base64urlToBuffer,
+    bufferToBase64url,
+} from "@github/webauthn-json/src/webauthn-json/base64url";
 import {
     CredentialCreationOptionsJSON,
     CredentialRequestOptionsJSON,

--- a/packages/passkeys/passkeys_web/javascript/src/passkeyAuthenticator.ts
+++ b/packages/passkeys/passkeys_web/javascript/src/passkeyAuthenticator.ts
@@ -1,10 +1,17 @@
 import {
-    create,
+    base64urlToBuffer,
+    bufferToBase64url,
+    createRequestFromJSON,
+    createResponseToJSON,
+    getRequestFromJSON,
+    getResponseToJSON,
+} from "@github/webauthn-json/extended";
+import {
     CredentialCreationOptionsJSON,
-    CredentialRequestOptionsJSON, get,
-    PublicKeyCredentialWithAssertionJSON
+    CredentialRequestOptionsJSON,
+    PublicKeyCredentialWithAssertionJSON,
+    PublicKeyCredentialWithAttestationJSON,
 } from "@github/webauthn-json";
-import {PublicKeyCredentialWithAttestationJSON} from "@github/webauthn-json/src/webauthn-json/basic/json";
 
 const ABORTED_BY_USER = 'operation aborted by user.';
 
@@ -17,9 +24,13 @@ export class PasskeyAuthenticator {
     async register(params: string): Promise<string> {
         try {
             const typedParams: CredentialCreationOptionsJSON = JSON.parse(params);
-            const out: PublicKeyCredentialWithAttestationJSON = await create(typedParams);
+            const request = createRequestFromJSON(typedParams);
+            applyPrfInput(request.publicKey, (typedParams.publicKey as any)?.extensions);
 
-            return JSON.stringify(out);
+            const credential = await navigator.credentials.create(request) as PublicKeyCredential;
+            const out: PublicKeyCredentialWithAttestationJSON = createResponseToJSON(credential);
+
+            return JSON.stringify(withPrfResults(out, credential));
         } catch (e) {
             let error: PlatformError;
             if (e instanceof DOMException) {
@@ -41,10 +52,13 @@ export class PasskeyAuthenticator {
             this.#abortController = new AbortController();
             const typedParams: CredentialRequestOptionsJSON = JSON.parse(params);
             typedParams.signal = this.#abortController.signal;
+            const request = getRequestFromJSON(typedParams);
+            applyPrfInput(request.publicKey, (typedParams.publicKey as any)?.extensions);
 
-            const out: PublicKeyCredentialWithAssertionJSON = await get(typedParams);
+            const credential = await navigator.credentials.get(request) as PublicKeyCredential;
+            const out: PublicKeyCredentialWithAssertionJSON = getResponseToJSON(credential);
 
-            return JSON.stringify(out);
+            return JSON.stringify(withPrfResults(out, credential));
         } catch (e) {
             let error: PlatformError;
             if (e instanceof DOMException) {
@@ -69,6 +83,50 @@ export class PasskeyAuthenticator {
 
         this.#abortController.abort(ABORTED_BY_USER);
     }
+}
+
+// The @github/webauthn-json schema does not know about the PRF extension, so
+// it drops the salts on the way in and the results on the way out. We convert
+// those base64url values ourselves and splice them back in.
+
+function applyPrfInput(publicKey: any, extensions: any): void {
+    const evalInput = extensions?.prf?.eval;
+    if (!evalInput) {
+        return;
+    }
+
+    const prf: { eval: { first: ArrayBuffer; second?: ArrayBuffer } } = {
+        eval: {first: base64urlToBuffer(evalInput.first)},
+    };
+    if (evalInput.second) {
+        prf.eval.second = base64urlToBuffer(evalInput.second);
+    }
+
+    publicKey.extensions = {...(publicKey.extensions || {}), prf};
+}
+
+function withPrfResults<T extends { clientExtensionResults?: any }>(
+    out: T,
+    credential: PublicKeyCredential,
+): T {
+    const prf = (credential.getClientExtensionResults() as any)?.prf;
+    if (!prf) {
+        return out;
+    }
+
+    const prfJson: { enabled?: boolean; results?: { first: string; second?: string } } = {};
+    if (typeof prf.enabled === 'boolean') {
+        prfJson.enabled = prf.enabled;
+    }
+    if (prf.results?.first) {
+        prfJson.results = {first: bufferToBase64url(prf.results.first)};
+        if (prf.results.second) {
+            prfJson.results.second = bufferToBase64url(prf.results.second);
+        }
+    }
+
+    out.clientExtensionResults = {...(out.clientExtensionResults || {}), prf: prfJson};
+    return out;
 }
 
 class PlatformError {
@@ -103,4 +161,3 @@ class PlatformError {
         return new PlatformError('suppressed', error, '');
     }
 }
-

--- a/packages/passkeys/passkeys_web/lib/models/passkeyLoginResponse.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkeyLoginResponse.dart
@@ -28,15 +28,17 @@ class PasskeyLoginResponse {
   Map<String, dynamic> toJson() => _$PasskeyLoginResponseToJson(this);
 
   /// Converts this response into the platform interface response type.
-  AuthenticateResponseType toAuthenticateResponseType() =>
-      AuthenticateResponseType(
-        clientDataJSON: response.clientDataJSON,
-        authenticatorData: response.authenticatorData,
-        signature: response.signature,
-        userHandle: response.userHandle ?? '',
-        id: id,
-        rawId: rawId,
-      );
+  AuthenticateResponseType toAuthenticateResponseType({
+    Map<String, dynamic>? clientExtensionResults,
+  }) => AuthenticateResponseType(
+    clientDataJSON: response.clientDataJSON,
+    authenticatorData: response.authenticatorData,
+    signature: response.signature,
+    userHandle: response.userHandle ?? '',
+    id: id,
+    rawId: rawId,
+    clientExtensionResults: clientExtensionResults,
+  );
 }
 
 /// The authenticator assertion data returned during a passkey login.

--- a/packages/passkeys/passkeys_web/lib/passkeys_web.dart
+++ b/packages/passkeys/passkeys_web/lib/passkeys_web.dart
@@ -51,7 +51,10 @@ class PasskeysWeb extends PasskeysPlatform {
     );
 
     try {
-      final serializedRequest = jsonEncode(r.toJson());
+      final requestJson = r.toJson();
+      _applyPrf(requestJson, request.prf);
+
+      final serializedRequest = jsonEncode(requestJson);
       final response = await authenticatorRegister(
         serializedRequest.toJS,
       ).toDart;
@@ -65,6 +68,8 @@ class PasskeysWeb extends PasskeysPlatform {
         clientDataJSON: typedResponse.response.clientDataJSON,
         attestationObject: typedResponse.response.attestationObject,
         transports: typedResponse.response.transports,
+        clientExtensionResults:
+            decodedResponse['clientExtensionResults'] as Map<String, dynamic>?,
       );
     } catch (e) {
       final exception = _parseException(e.toString());
@@ -86,17 +91,38 @@ class PasskeysWeb extends PasskeysPlatform {
     );
 
     try {
-      final serializedRequest = jsonEncode(r.toJson());
+      final requestJson = r.toJson();
+      _applyPrf(requestJson, request.prf);
+
+      final serializedRequest = jsonEncode(requestJson);
       final response = await authenticatorLogin(serializedRequest.toJS).toDart;
       final decodedResponse =
           jsonDecode(response.toDart) as Map<String, dynamic>;
       final typedResponse = PasskeyLoginResponse.fromJson(decodedResponse);
 
-      return typedResponse.toAuthenticateResponseType();
+      return typedResponse.toAuthenticateResponseType(
+        clientExtensionResults:
+            decodedResponse['clientExtensionResults'] as Map<String, dynamic>?,
+      );
     } catch (e) {
       final exception = _parseException(e.toString());
       throw exception;
     }
+  }
+
+  /// Adds the WebAuthn PRF extension salt to the serialized [requestJson] so
+  /// the JS layer can forward it to the browser's WebAuthn API.
+  void _applyPrf(Map<String, dynamic> requestJson, String? prf) {
+    if (prf == null) {
+      return;
+    }
+
+    final publicKey = requestJson['publicKey'] as Map<String, dynamic>;
+    publicKey['extensions'] = {
+      'prf': {
+        'eval': {'first': prf},
+      },
+    };
   }
 
   PlatformException _parseException(String exception) {

--- a/packages/passkeys/passkeys_web/lib/passkeys_web.dart
+++ b/packages/passkeys/passkeys_web/lib/passkeys_web.dart
@@ -118,11 +118,13 @@ class PasskeysWeb extends PasskeysPlatform {
     }
 
     final publicKey = requestJson['publicKey'] as Map<String, dynamic>;
-    publicKey['extensions'] = {
-      'prf': {
-        'eval': {'first': prf},
-      },
+    final extensions =
+        (publicKey['extensions'] as Map<String, dynamic>?) ??
+        <String, dynamic>{};
+    extensions['prf'] = {
+      'eval': {'first': prf},
     };
+    publicKey['extensions'] = extensions;
   }
 
   PlatformException _parseException(String exception) {


### PR DESCRIPTION
## What

Adds WebAuthn **PRF** extension support to `passkeys_web`, bringing the web platform to parity with iOS, macOS and Android (PRF was added there in #263).

Closes part of #210.

## Why

PRF (and the underlying CTAP2 `hmac-secret` extension) lets apps derive a stable secret from a passkey, useful for encrypting data. It was already wired through the platform interface types (`RegisterRequestType.prf`, `AuthenticateRequestType.prf`, `clientExtensionResults`) and implemented natively on Apple/Android platforms, but the web implementation ignored it.

## How

`@github/webauthn-json`'s conversion schema does not know about the PRF extension, so its `create()`/`get()` helpers silently drop the salts on the way in and the results on the way out (the schema only handles `appid`, `appidExclude`, `credProps`).

- **TypeScript**: switch from `create()`/`get()` to the library's lower-level `createRequestFromJSON`/`getRequestFromJSON` + `createResponseToJSON`/`getResponseToJSON` steps, call `navigator.credentials` directly, and splice the PRF salt (base64url → ArrayBuffer) into `publicKey.extensions.prf.eval` and the PRF results (ArrayBuffer → base64url) out of `getClientExtensionResults()` ourselves. Everything else keeps using the library.
- **Dart**: forward `request.prf` into the serialized request's `publicKey.extensions` and surface `clientExtensionResults` on `RegisterResponseType`/`AuthenticateResponseType`.
- Rebuilt `bundle.js` and copied it to the example (`melos run build-passkeys-web-javascript`).

The emitted `clientExtensionResults.prf` shape (`{ enabled, results: { first, second? } }`) matches the Apple/Android implementations.

## Testing

- `npm run build` compiles the TypeScript cleanly.
- `dart analyze` passes for `passkeys_web`.
- Manual end-to-end verification against a PRF-capable browser/relying party still needs to be done by someone with the example set up.