### PR TITLE
docs(passkeys): document the PRF extension

### DIFF
--- a/packages/passkeys/passkeys/README.md
+++ b/packages/passkeys/passkeys/README.md
@@ -15,6 +15,7 @@ on Vercel).
 
 - sign up and login users with passkeys on iOS, Android and Web
 - login users with conditional UI
+- derive secrets from a passkey through the WebAuthn PRF extension (see [Using the PRF extension](#using-the-prf-extension))
 
 ## Getting started
 
@@ -217,6 +218,74 @@ if (kIsWeb) {
 ```
 
 </details>
+
+## Using the PRF extension
+
+The WebAuthn [PRF extension](https://w3c.github.io/webauthn/#prf-extension) (backed by the CTAP2
+`hmac-secret` extension) lets you derive a stable, high-entropy secret from a passkey. Because the
+secret never leaves the authenticator and is reproducible on every authentication, it is a good
+building block for client side encryption (for example to seed a symmetric key that encrypts a
+user's data).
+
+You pass a base64url encoded `prf` salt into the register and authenticate requests, and read the
+derived secret back from `clientExtensionResults`.
+
+### Platform support
+
+| Android            | iOS                   | macOS                  | Web                | Windows | Linux |
+| ------------------ | --------------------- | ---------------------- | ------------------ | ------- | ----- |
+| :white_check_mark: | :white_check_mark: (18+) | :white_check_mark: (15+) | :white_check_mark: | :x:     | :x:   |
+
+The salt is typically coordinated with your relying party server (it is part of the WebAuthn
+`extensions.prf.eval.first` input). Registration usually only reports whether PRF is `enabled`,
+while the derived secret (`results.first`) is returned during authentication.
+
+### Registration
+
+```dart
+final authenticator = PasskeyAuthenticator();
+
+final response = await authenticator.register(
+  RegisterRequestType(
+    challenge: challenge,
+    relyingParty: relyingParty,
+    user: user,
+    excludeCredentials: const [],
+    // Base64URL encoded salt, without padding.
+    prf: prfSalt,
+  ),
+);
+
+// During registration platforms typically only tell you whether PRF is
+// available for the newly created credential.
+final prf = response.clientExtensionResults?['prf'] as Map?;
+final prfEnabled = prf?['enabled'] == true;
+```
+
+### Authentication
+
+```dart
+final authenticator = PasskeyAuthenticator();
+
+final response = await authenticator.authenticate(
+  AuthenticateRequestType(
+    relyingPartyId: relyingPartyId,
+    challenge: challenge,
+    mediation: MediationType.Optional,
+    preferImmediatelyAvailableCredentials: false,
+    // Use the same salt you used during registration to obtain the same secret.
+    prf: prfSalt,
+  ),
+);
+
+// The derived secret is returned as a base64url encoded string.
+final results =
+    (response.clientExtensionResults?['prf'] as Map?)?['results'] as Map?;
+final secret = results?['first'] as String?;
+```
+
+Use `secret` (after base64url decoding it) as key material for your encryption, but never send it to
+your relying party server.
 
 ## Troubleshooting
 

--- a/packages/passkeys/passkeys/README.md
+++ b/packages/passkeys/passkeys/README.md
@@ -232,9 +232,9 @@ derived secret back from `clientExtensionResults`.
 
 ### Platform support
 
-| Android            | iOS                   | macOS                  | Web                | Windows | Linux |
-| ------------------ | --------------------- | ---------------------- | ------------------ | ------- | ----- |
-| :white_check_mark: | :white_check_mark: (18+) | :white_check_mark: (15+) | :white_check_mark: | :x:     | :x:   |
+| Android            | iOS                   | macOS                  | Web                | Windows            | Linux |
+| ------------------ | --------------------- | ---------------------- | ------------------ | ------------------ | ----- |
+| :white_check_mark: | :white_check_mark: (18+) | :white_check_mark: (15+) | :white_check_mark: | :white_check_mark: | :x:   |
 
 The salt is typically coordinated with your relying party server (it is part of the WebAuthn
 `extensions.prf.eval.first` input). Registration usually only reports whether PRF is `enabled`,

--- a/packages/passkeys/passkeys/README.md
+++ b/packages/passkeys/passkeys/README.md
@@ -222,13 +222,13 @@ if (kIsWeb) {
 ## Using the PRF extension
 
 The WebAuthn [PRF extension](https://w3c.github.io/webauthn/#prf-extension) (backed by the CTAP2
-`hmac-secret` extension) lets you derive a stable, high-entropy secret from a passkey. Because the
-secret never leaves the authenticator and is reproducible on every authentication, it is a good
-building block for client side encryption (for example to seed a symmetric key that encrypts a
-user's data).
+`hmac-secret` extension) lets you derive a stable, high-entropy secret from a passkey. The
+underlying key material never leaves the authenticator, and the derived secret is reproducible on
+every authentication, so it is a good building block for client-side encryption (for example to seed
+a symmetric key that encrypts a user's data).
 
-You pass a base64url encoded `prf` salt into the register and authenticate requests, and read the
-derived secret back from `clientExtensionResults`.
+You pass a base64url-encoded `prf` salt into the registration and authentication requests, and read
+the derived secret back from `clientExtensionResults`.
 
 ### Platform support
 
@@ -278,13 +278,13 @@ final response = await authenticator.authenticate(
   ),
 );
 
-// The derived secret is returned as a base64url encoded string.
+// The derived secret is returned as a base64url-encoded string.
 final results =
     (response.clientExtensionResults?['prf'] as Map?)?['results'] as Map?;
 final secret = results?['first'] as String?;
 ```
 
-Use `secret` (after base64url decoding it) as key material for your encryption, but never send it to
+Use `secret` (after base64url-decoding it) as key material for your encryption, but never send it to
 your relying party server.
 
 ## Troubleshooting


### PR DESCRIPTION
## What

Documents the WebAuthn **PRF** extension in the `passkeys` package README.

Part of #210.

## Why

PRF support was added for iOS/macOS/Android in #263 (and for web in #274), but it was never documented, so consumers had no way to discover the `prf` request field or the `clientExtensionResults` on the responses.

## How

Adds a "Using the PRF extension" section that covers:

- what PRF is and why it is useful (client side encryption keyed off a passkey);
- a platform support table (Android, iOS 18+, macOS 15+, Web; not Windows/Linux);
- register and authenticate code snippets showing how to pass the `prf` salt and read the derived secret back out of `clientExtensionResults`;
- a note not to send the derived secret to the relying party server.

Docs-only change.