### PR TITLE
chore(passkeys_android): make the Android build ready for built-in Kotlin

### DIFF
--- a/packages/passkeys/passkeys_android/android/build.gradle
+++ b/packages/passkeys/passkeys_android/android/build.gradle
@@ -1,19 +1,6 @@
 group 'com.corbado.passkeys_android'
 version '1.0-SNAPSHOT'
 
-buildscript {
-    ext.kotlin_version = '1.8.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 rootProject.allprojects {
     repositories {
         google()
@@ -22,7 +9,15 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// Only apply the Kotlin Gradle Plugin when the consuming app does not use the
+// Android Gradle Plugin's built-in Kotlin support (AGP 9, opt in with
+// android.builtInKotlin=true). This keeps the plugin building on older setups
+// while dropping the KGP dependency once built-in Kotlin is enabled.
+def builtInKotlin = (project.findProperty('android.builtInKotlin') ?: 'false') == 'true'
+if (!builtInKotlin) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -33,12 +28,8 @@ android {
     compileSdkVersion 34
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_9
-        targetCompatibility JavaVersion.VERSION_1_9
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -51,8 +42,13 @@ android {
     }
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
+
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.annotation:annotation:1.6.0'
     implementation("androidx.credentials:credentials:1.3.0")
 

--- a/packages/passkeys/passkeys_android/android/build.gradle
+++ b/packages/passkeys/passkeys_android/android/build.gradle
@@ -44,7 +44,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the example Android template migration (#270). That change surfaced a warning that some plugins, including `passkeys_android`, still apply the Kotlin Gradle Plugin (KGP) rather than using the Android Gradle Plugin's built-in Kotlin. This readies `passkeys_android` for built-in Kotlin.

## What changed

In `passkeys_android/android/build.gradle`:

- Drop the legacy `buildscript` block that pinned the Android Gradle Plugin 7.4.2 and Kotlin 1.8.10, so the plugin inherits both from the consuming app.
- Replace `kotlinOptions` with the `kotlin { compilerOptions }` DSL and target Java 17.
- Apply the Kotlin Gradle Plugin only when the app does not enable built-in Kotlin (`android.builtInKotlin=true`).

## Behaviour

With the current `flutter create` default (`android.builtInKotlin=false`), the plugin still applies the Kotlin Gradle Plugin, so nothing changes today. It stops applying it, and drops out of the "plugins that apply KGP" warning, once an app opts into built-in Kotlin.

Enabling built-in Kotlin app-wide is currently blocked by third party plugins (for example `device_info_plus` and `patrol`) that still apply KGP, so it cannot be turned on in the example yet. This change makes `passkeys_android` ready for that day without forcing a Flutter version bump on consumers.

## Verification

- `flutter build apk --debug` succeeds on Flutter 3.44.5 (the plugin still applies KGP under the default flag).