### PR TITLE
feat(passkeys): expose WebAuthn Signal API

### DIFF
--- a/packages/passkeys/passkeys/lib/authenticator.dart
+++ b/packages/passkeys/passkeys/lib/authenticator.dart
@@ -161,6 +161,72 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
     }
   }
 
+  /// Signals to the platform that a credential is no longer recognized by the
+  /// relying party.
+  ///
+  /// Call this after the server rejects an assertion because the credential was
+  /// deleted server-side. On platforms that support the WebAuthn Signal API
+  /// (Android, iOS, macOS and web) this removes the stale credential from the
+  /// passkey picker and autofill suggestions. On platforms without support the
+  /// call is a no-op.
+  @override
+  Future<void> signalUnknownCredential(
+    SignalUnknownCredentialRequestType request,
+  ) async {
+    try {
+      _isValidCredentialID(request.credentialId);
+
+      await _platform.signalUnknownCredential(request);
+    } on PlatformException catch (e) {
+      _mapSignalException(e);
+    }
+  }
+
+  /// Signals to the platform the complete set of credentials that the relying
+  /// party still accepts for a user.
+  ///
+  /// On platforms that support the WebAuthn Signal API (Android, iOS, macOS and
+  /// web) any credentials not contained in
+  /// [SignalAllAcceptedCredentialsRequestType.allAcceptedCredentialIds] are
+  /// pruned from the passkey picker. On platforms without support the call is a
+  /// no-op.
+  @override
+  Future<void> signalAllAcceptedCredentials(
+    SignalAllAcceptedCredentialsRequestType request,
+  ) async {
+    try {
+      _isValidUserID(request.userId);
+      for (final credentialId in request.allAcceptedCredentialIds) {
+        _isValidCredentialID(credentialId);
+      }
+
+      await _platform.signalAllAcceptedCredentials(request);
+    } on PlatformException catch (e) {
+      _mapSignalException(e);
+    }
+  }
+
+  Never _mapSignalException(PlatformException e) {
+    if (debugMode) {
+      _doctor.recordException(e);
+    }
+
+    switch (e.code) {
+      case 'cancelled':
+        throw PasskeyAuthCancelledException();
+      case 'domain-not-associated':
+        throw DomainNotAssociatedException(e.message);
+      case 'deviceNotSupported':
+        throw DeviceNotSupportedException();
+      default:
+        if (e.code.startsWith('android-unhandled') ||
+            e.code.startsWith('ios-unhandled')) {
+          throw UnhandledAuthenticatorException(e.code, e.message, e.details);
+        }
+        throw e;
+    }
+  }
+
   /// Returns platform-specific information about the availability of passkeys.
   ///
   /// This function returns an instance of [GetAvailability], which provides

--- a/packages/passkeys/passkeys/lib/authenticator.dart
+++ b/packages/passkeys/passkeys/lib/authenticator.dart
@@ -165,10 +165,14 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
   /// relying party.
   ///
   /// Call this after the server rejects an assertion because the credential was
-  /// deleted server-side. On platforms that support the WebAuthn Signal API
-  /// (Android, iOS, macOS and web) this removes the stale credential from the
-  /// passkey picker and autofill suggestions. On platforms without support the
-  /// call is a no-op.
+  /// deleted server-side. Where supported this removes the stale credential
+  /// from the passkey picker and autofill suggestions.
+  ///
+  /// This is a best-effort hint. It is only acted upon on Android (with a
+  /// Credential Manager provider that supports the Signal API), iOS 26.2 and
+  /// later, macOS 26.2 and later, and browsers that expose
+  /// `PublicKeyCredential.signalUnknownCredential`. On every other platform or
+  /// OS version, including older iOS and macOS releases, the call is a no-op.
   @override
   Future<void> signalUnknownCredential(
     SignalUnknownCredentialRequestType request,
@@ -185,11 +189,16 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
   /// Signals to the platform the complete set of credentials that the relying
   /// party still accepts for a user.
   ///
-  /// On platforms that support the WebAuthn Signal API (Android, iOS, macOS and
-  /// web) any credentials not contained in
+  /// Where supported any credentials not contained in
   /// [SignalAllAcceptedCredentialsRequestType.allAcceptedCredentialIds] are
-  /// pruned from the passkey picker. On platforms without support the call is a
-  /// no-op.
+  /// pruned from the passkey picker.
+  ///
+  /// This is a best-effort hint. It is only acted upon on Android (with a
+  /// Credential Manager provider that supports the Signal API), iOS 26.2 and
+  /// later, macOS 26.2 and later, and browsers that expose
+  /// `PublicKeyCredential.signalAllAcceptedCredentials`. On every other
+  /// platform or OS version, including older iOS and macOS releases, the call
+  /// is a no-op.
   @override
   Future<void> signalAllAcceptedCredentials(
     SignalAllAcceptedCredentialsRequestType request,

--- a/packages/passkeys/passkeys/lib/authenticator.dart
+++ b/packages/passkeys/passkeys/lib/authenticator.dart
@@ -177,8 +177,8 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
       _isValidCredentialID(request.credentialId);
 
       await _platform.signalUnknownCredential(request);
-    } on PlatformException catch (e) {
-      _mapSignalException(e);
+    } on PlatformException catch (e, stackTrace) {
+      _mapSignalException(e, stackTrace);
     }
   }
 
@@ -201,12 +201,12 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
       }
 
       await _platform.signalAllAcceptedCredentials(request);
-    } on PlatformException catch (e) {
-      _mapSignalException(e);
+    } on PlatformException catch (e, stackTrace) {
+      _mapSignalException(e, stackTrace);
     }
   }
 
-  Never _mapSignalException(PlatformException e) {
+  Never _mapSignalException(PlatformException e, StackTrace stackTrace) {
     if (debugMode) {
       _doctor.recordException(e);
     }
@@ -223,7 +223,7 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
             e.code.startsWith('ios-unhandled')) {
           throw UnhandledAuthenticatorException(e.code, e.message, e.details);
         }
-        throw e;
+        Error.throwWithStackTrace(e, stackTrace);
     }
   }
 

--- a/packages/passkeys/passkeys_android/android/build.gradle
+++ b/packages/passkeys/passkeys_android/android/build.gradle
@@ -30,7 +30,7 @@ android {
         namespace 'com.corbado.passkeys_android'
     }
 
-    compileSdkVersion 34
+    compileSdkVersion 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_9
@@ -54,11 +54,11 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.annotation:annotation:1.6.0'
-    implementation("androidx.credentials:credentials:1.3.0")
+    implementation("androidx.credentials:credentials:1.6.0")
 
     // optional - needed for credentials support from play services, for devices running
     // Android 13 and below.0
-    implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
+    implementation("androidx.credentials:credentials-play-services-auth:1.6.0")
     implementation 'com.google.android.gms:play-services-auth:20.5.0'
     implementation 'com.google.android.gms:play-services-fido:20.0.1'
     implementation 'androidx.multidex:multidex:2.0.1'

--- a/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/FlutterPasskeysPlugin.java
+++ b/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/FlutterPasskeysPlugin.java
@@ -1,6 +1,7 @@
 package com.corbado.passkeys_android;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
 import android.os.Build;
@@ -21,6 +22,7 @@ import io.flutter.plugin.common.MethodChannel;
 public class FlutterPasskeysPlugin extends FlutterActivity implements FlutterPlugin, ActivityAware {
     private static final String TAG = "FlutterPasskeysPlugin";
     private BinaryMessenger binaryMessenger;
+    private Context applicationContext;
     private Activity activity;
 
     public FlutterPasskeysPlugin() {
@@ -29,11 +31,18 @@ public class FlutterPasskeysPlugin extends FlutterActivity implements FlutterPlu
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
         binaryMessenger = binding.getBinaryMessenger();
+        applicationContext = binding.getApplicationContext();
     }
 
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
         binaryMessenger = null;
+        applicationContext = null;
+    }
+
+    public Context requireApplicationContext() {
+        if (applicationContext == null) throw new IllegalStateException("Application context not found");
+        return applicationContext;
     }
 
     @Override

--- a/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
+++ b/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
@@ -15,6 +15,10 @@ import androidx.credentials.GetCredentialRequest;
 import androidx.credentials.GetCredentialResponse;
 import androidx.credentials.GetPublicKeyCredentialOption;
 import androidx.credentials.PublicKeyCredential;
+import androidx.credentials.SignalAllAcceptedCredentialIdsRequest;
+import androidx.credentials.SignalCredentialStateRequest;
+import androidx.credentials.SignalCredentialStateResponse;
+import androidx.credentials.SignalUnknownCredentialRequest;
 import androidx.credentials.exceptions.CreateCredentialCancellationException;
 import androidx.credentials.exceptions.CreateCredentialException;
 import androidx.credentials.exceptions.CreateCredentialNoCreateOptionException;
@@ -23,6 +27,7 @@ import androidx.credentials.exceptions.GetCredentialException;
 import androidx.credentials.exceptions.NoCredentialException;
 import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException;
 import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException;
+import androidx.credentials.exceptions.publickeycredential.SignalCredentialStateException;
 
 import com.corbado.passkeys_android.models.login.AllowCredentialType;
 import com.corbado.passkeys_android.models.login.GetCredentialOptions;
@@ -381,6 +386,48 @@ public class MessageHandler implements Messages.PasskeysApi {
         }
 
         result.success(null);
+    }
+
+    @Override
+    public void signalUnknownCredential(@NonNull String relyingPartyId, @NonNull String credentialId, @NonNull Messages.Result<Void> result) {
+        try {
+            JSONObject requestJson = new JSONObject();
+            requestJson.put("rpId", relyingPartyId);
+            requestJson.put("credentialId", credentialId);
+            signalCredentialState(new SignalUnknownCredentialRequest(requestJson.toString()), result);
+        } catch (JSONException e) {
+            result.error(e);
+        }
+    }
+
+    @Override
+    public void signalAllAcceptedCredentials(@NonNull String relyingPartyId, @NonNull String userId, @NonNull List<String> allAcceptedCredentialIds, @NonNull Messages.Result<Void> result) {
+        try {
+            JSONObject requestJson = new JSONObject();
+            requestJson.put("rpId", relyingPartyId);
+            requestJson.put("userId", userId);
+            requestJson.put("allAcceptedCredentialIds", new JSONArray(allAcceptedCredentialIds));
+            signalCredentialState(new SignalAllAcceptedCredentialIdsRequest(requestJson.toString()), result);
+        } catch (JSONException e) {
+            result.error(e);
+        }
+    }
+
+    private void signalCredentialState(SignalCredentialStateRequest request, @NonNull Messages.Result<Void> result) {
+        Activity activity = plugin.requireActivity();
+        CredentialManager credentialManager = CredentialManager.create(activity);
+        credentialManager.signalCredentialStateAsync(request, Runnable::run,
+                new CredentialManagerCallback<SignalCredentialStateResponse, SignalCredentialStateException>() {
+                    @Override
+                    public void onResult(SignalCredentialStateResponse res) {
+                        result.success(null);
+                    }
+
+                    @Override
+                    public void onError(SignalCredentialStateException e) {
+                        result.error(new Messages.FlutterError("android-unhandled: " + e.getType(), e.getMessage(), null));
+                    }
+                });
     }
 
     private static Map<String, Object> parsePrfExtensionResults(JSONObject json) {

--- a/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
+++ b/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/MessageHandler.java
@@ -414,8 +414,9 @@ public class MessageHandler implements Messages.PasskeysApi {
     }
 
     private void signalCredentialState(SignalCredentialStateRequest request, @NonNull Messages.Result<Void> result) {
-        Activity activity = plugin.requireActivity();
-        CredentialManager credentialManager = CredentialManager.create(activity);
+        // The Signal API does not present any UI, so it can run without a
+        // foreground activity (e.g. right after a backgrounded server response).
+        CredentialManager credentialManager = CredentialManager.create(plugin.requireApplicationContext());
         credentialManager.signalCredentialStateAsync(request, Runnable::run,
                 new CredentialManagerCallback<SignalCredentialStateResponse, SignalCredentialStateException>() {
                     @Override

--- a/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/Messages.java
+++ b/packages/passkeys/passkeys_android/android/src/main/java/com/corbado/passkeys_android/Messages.java
@@ -1104,6 +1104,10 @@ public class Messages {
 
     void cancelCurrentAuthenticatorOperation(@NonNull Result<Void> result);
 
+    void signalUnknownCredential(@NonNull String relyingPartyId, @NonNull String credentialId, @NonNull Result<Void> result);
+
+    void signalAllAcceptedCredentials(@NonNull String relyingPartyId, @NonNull String userId, @NonNull List<String> allAcceptedCredentialIds, @NonNull Result<Void> result);
+
     /** The codec used by PasskeysApi. */
     static @NonNull MessageCodec<Object> getCodec() {
       return PasskeysApiCodec.INSTANCE;
@@ -1258,6 +1262,67 @@ public class Messages {
                     };
 
                 api.cancelCurrentAuthenticatorOperation(resultCallback);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.passkeys_android.PasskeysApi.signalUnknownCredential", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String relyingPartyIdArg = (String) args.get(0);
+                String credentialIdArg = (String) args.get(1);
+                Result<Void> resultCallback =
+                    new Result<Void>() {
+                      public void success(Void result) {
+                        wrapped.add(0, null);
+                        reply.reply(wrapped);
+                      }
+
+                      public void error(Throwable error) {
+                        ArrayList<Object> wrappedError = wrapError(error);
+                        reply.reply(wrappedError);
+                      }
+                    };
+
+                api.signalUnknownCredential(relyingPartyIdArg, credentialIdArg, resultCallback);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.passkeys_android.PasskeysApi.signalAllAcceptedCredentials", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String relyingPartyIdArg = (String) args.get(0);
+                String userIdArg = (String) args.get(1);
+                List<String> allAcceptedCredentialIdsArg = (List<String>) args.get(2);
+                Result<Void> resultCallback =
+                    new Result<Void>() {
+                      public void success(Void result) {
+                        wrapped.add(0, null);
+                        reply.reply(wrapped);
+                      }
+
+                      public void error(Throwable error) {
+                        ArrayList<Object> wrappedError = wrapError(error);
+                        reply.reply(wrappedError);
+                      }
+                    };
+
+                api.signalAllAcceptedCredentials(relyingPartyIdArg, userIdArg, allAcceptedCredentialIdsArg, resultCallback);
               });
         } else {
           channel.setMessageHandler(null);

--- a/packages/passkeys/passkeys_android/lib/messages.g.dart
+++ b/packages/passkeys/passkeys_android/lib/messages.g.dart
@@ -567,4 +567,65 @@ class PasskeysApi {
       return;
     }
   }
+
+  Future<void> signalUnknownCredential(
+    String arg_relyingPartyId,
+    String arg_credentialId,
+  ) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+      'dev.flutter.pigeon.passkeys_android.PasskeysApi.signalUnknownCredential',
+      codec,
+      binaryMessenger: _binaryMessenger,
+    );
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_relyingPartyId, arg_credentialId])
+            as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> signalAllAcceptedCredentials(
+    String arg_relyingPartyId,
+    String arg_userId,
+    List<String?> arg_allAcceptedCredentialIds,
+  ) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+      'dev.flutter.pigeon.passkeys_android.PasskeysApi.signalAllAcceptedCredentials',
+      codec,
+      binaryMessenger: _binaryMessenger,
+    );
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[
+              arg_relyingPartyId,
+              arg_userId,
+              arg_allAcceptedCredentialIds,
+            ])
+            as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
 }

--- a/packages/passkeys/passkeys_android/lib/passkeys_android.dart
+++ b/packages/passkeys/passkeys_android/lib/passkeys_android.dart
@@ -115,6 +115,27 @@ class PasskeysAndroid extends PasskeysPlatform {
     return _api.cancelCurrentAuthenticatorOperation();
   }
 
+  @override
+  Future<void> signalUnknownCredential(
+    SignalUnknownCredentialRequestType request,
+  ) {
+    return _api.signalUnknownCredential(
+      request.relyingPartyId,
+      request.credentialId,
+    );
+  }
+
+  @override
+  Future<void> signalAllAcceptedCredentials(
+    SignalAllAcceptedCredentialsRequestType request,
+  ) {
+    return _api.signalAllAcceptedCredentials(
+      request.relyingPartyId,
+      request.userId,
+      request.allAcceptedCredentialIds,
+    );
+  }
+
   // In case of android we link passkey support to the availability of the
   // biometric authentication
   @override

--- a/packages/passkeys/passkeys_android/pigeons/messages.dart
+++ b/packages/passkeys/passkeys_android/pigeons/messages.dart
@@ -201,4 +201,14 @@ abstract class PasskeysApi {
 
   @async
   void cancelCurrentAuthenticatorOperation();
+
+  @async
+  void signalUnknownCredential(String relyingPartyId, String credentialId);
+
+  @async
+  void signalAllAcceptedCredentials(
+    String relyingPartyId,
+    String userId,
+    List<String> allAcceptedCredentialIds,
+  );
 }

--- a/packages/passkeys/passkeys_android/test/passkeys_android_test.dart
+++ b/packages/passkeys/passkeys_android/test/passkeys_android_test.dart
@@ -7,6 +7,29 @@ import 'package:passkeys_platform_interface/types/types.dart';
 class _FakePasskeysApi extends pigeon.PasskeysApi {
   String? registerSalt;
   String? authenticateSalt;
+  List<Object?>? signalUnknownCredentialArgs;
+  List<Object?>? signalAllAcceptedCredentialsArgs;
+
+  @override
+  Future<void> signalUnknownCredential(
+    String relyingPartyId,
+    String credentialId,
+  ) async {
+    signalUnknownCredentialArgs = [relyingPartyId, credentialId];
+  }
+
+  @override
+  Future<void> signalAllAcceptedCredentials(
+    String relyingPartyId,
+    String userId,
+    List<String?> allAcceptedCredentialIds,
+  ) async {
+    signalAllAcceptedCredentialsArgs = [
+      relyingPartyId,
+      userId,
+      allAcceptedCredentialIds,
+    ];
+  }
 
   @override
   Future<pigeon.RegisterResponse> register(
@@ -127,6 +150,39 @@ void main() {
         response.clientExtensionResults?['prf'],
         isA<Map<dynamic, dynamic>>(),
       );
+    });
+
+    test('signalUnknownCredential forwards its arguments', () async {
+      final api = _FakePasskeysApi();
+      final platform = PasskeysAndroid(api: api);
+
+      await platform.signalUnknownCredential(
+        const SignalUnknownCredentialRequestType(
+          relyingPartyId: 'example.com',
+          credentialId: 'credential-id',
+        ),
+      );
+
+      expect(api.signalUnknownCredentialArgs, ['example.com', 'credential-id']);
+    });
+
+    test('signalAllAcceptedCredentials forwards its arguments', () async {
+      final api = _FakePasskeysApi();
+      final platform = PasskeysAndroid(api: api);
+
+      await platform.signalAllAcceptedCredentials(
+        const SignalAllAcceptedCredentialsRequestType(
+          relyingPartyId: 'example.com',
+          userId: 'user-id',
+          allAcceptedCredentialIds: ['cred-1', 'cred-2'],
+        ),
+      );
+
+      expect(api.signalAllAcceptedCredentialsArgs, [
+        'example.com',
+        'user-id',
+        ['cred-1', 'cred-2'],
+      ]);
     });
   });
 }

--- a/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/PasskeysPlugin.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/PasskeysPlugin.swift
@@ -224,9 +224,11 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
                         relyingPartyIdentifier: relyingPartyId,
                         credentialID: credentialData
                     )
-                    completion(.success(()))
+                    DispatchQueue.main.async { completion(.success(())) }
                 } catch {
-                    completion(.failure(FlutterError(fromNSError: error as NSError)))
+                    DispatchQueue.main.async {
+                        completion(.failure(FlutterError(fromNSError: error as NSError)))
+                    }
                 }
             }
         } else {
@@ -252,9 +254,11 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
                         userHandle: userHandle,
                         acceptedCredentialIDs: credentialIDs
                     )
-                    completion(.success(()))
+                    DispatchQueue.main.async { completion(.success(())) }
                 } catch {
-                    completion(.failure(FlutterError(fromNSError: error as NSError)))
+                    DispatchQueue.main.async {
+                        completion(.failure(FlutterError(fromNSError: error as NSError)))
+                    }
                 }
             }
         } else {

--- a/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/PasskeysPlugin.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/PasskeysPlugin.swift
@@ -244,7 +244,16 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
             return
         }
 
-        let credentialIDs = allAcceptedCredentialIds.compactMap { Data.fromBase64Url($0) }
+        var credentialIDs = [Data]()
+        for credentialId in allAcceptedCredentialIds {
+            guard let credentialData = Data.fromBase64Url(credentialId) else {
+                // Never signal a partial list, that would prune credentials
+                // that are actually still accepted. Treat it as a no-op.
+                completion(.success(()))
+                return
+            }
+            credentialIDs.append(credentialData)
+        }
 
         if #available(iOS 26.2, macOS 26.2, *) {
             Task {

--- a/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/PasskeysPlugin.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/PasskeysPlugin.swift
@@ -210,7 +210,60 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
         inFlightController?.cancel()
         completion(.success(()))
     }
-    
+
+    func signalUnknownCredential(relyingPartyId: String, credentialId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let credentialData = Data.fromBase64Url(credentialId) else {
+            completion(.success(()))
+            return
+        }
+
+        if #available(iOS 26.2, macOS 26.2, *) {
+            Task {
+                do {
+                    try await ASCredentialDataManager().reportUnknownPublicKeyCredential(
+                        relyingPartyIdentifier: relyingPartyId,
+                        credentialID: credentialData
+                    )
+                    completion(.success(()))
+                } catch {
+                    completion(.failure(FlutterError(fromNSError: error as NSError)))
+                }
+            }
+        } else {
+            // The Signal API is unavailable on this OS version; the hint is
+            // best-effort so treat it as a no-op.
+            completion(.success(()))
+        }
+    }
+
+    func signalAllAcceptedCredentials(relyingPartyId: String, userId: String, allAcceptedCredentialIds: [String], completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let userHandle = Data.fromBase64Url(userId) else {
+            completion(.success(()))
+            return
+        }
+
+        let credentialIDs = allAcceptedCredentialIds.compactMap { Data.fromBase64Url($0) }
+
+        if #available(iOS 26.2, macOS 26.2, *) {
+            Task {
+                do {
+                    try await ASCredentialDataManager().reportAllAcceptedPublicKeyCredentials(
+                        relyingPartyIdentifier: relyingPartyId,
+                        userHandle: userHandle,
+                        acceptedCredentialIDs: credentialIDs
+                    )
+                    completion(.success(()))
+                } catch {
+                    completion(.failure(FlutterError(fromNSError: error as NSError)))
+                }
+            }
+        } else {
+            // The Signal API is unavailable on this OS version; the hint is
+            // best-effort so treat it as a no-op.
+            completion(.success(()))
+        }
+    }
+
     private func parseCredentials(credentials: [CredentialType]) -> [ASAuthorizationPlatformPublicKeyCredentialDescriptor] {
         return credentials.compactMap { credential in
             guard let credentialData = Data.fromBase64Url(credential.id) else {

--- a/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/messages.swift
+++ b/packages/passkeys/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/messages.swift
@@ -280,6 +280,8 @@ protocol PasskeysApi {
   func register(challenge: String, relyingParty: RelyingParty, user: User, excludeCredentials: [CredentialType], pubKeyCredValues: [Int64], canBePlatformAuthenticator: Bool, canBeSecurityKey: Bool, residentKeyPreference: String?, attestationPreference: String?, salt: String?, completion: @escaping (Result<RegisterResponse, Error>) -> Void)
   func authenticate(relyingPartyId: String, challenge: String, conditionalUI: Bool, allowedCredentials: [CredentialType], preferImmediatelyAvailableCredentials: Bool, salt: String?, completion: @escaping (Result<AuthenticateResponse, Error>) -> Void)
   func cancelCurrentAuthenticatorOperation(completion: @escaping (Result<Void, Error>) -> Void)
+  func signalUnknownCredential(relyingPartyId: String, credentialId: String, completion: @escaping (Result<Void, Error>) -> Void)
+  func signalAllAcceptedCredentials(relyingPartyId: String, userId: String, allAcceptedCredentialIds: [String], completion: @escaping (Result<Void, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -376,6 +378,43 @@ class PasskeysApiSetup {
       }
     } else {
       cancelCurrentAuthenticatorOperationChannel.setMessageHandler(nil)
+    }
+    let signalUnknownCredentialChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.passkeys_darwin.PasskeysApi.signalUnknownCredential", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      signalUnknownCredentialChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let relyingPartyIdArg = args[0] as! String
+        let credentialIdArg = args[1] as! String
+        api.signalUnknownCredential(relyingPartyId: relyingPartyIdArg, credentialId: credentialIdArg) { result in
+          switch result {
+            case .success:
+              reply(wrapResult(nil))
+            case .failure(let error):
+              reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      signalUnknownCredentialChannel.setMessageHandler(nil)
+    }
+    let signalAllAcceptedCredentialsChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.passkeys_darwin.PasskeysApi.signalAllAcceptedCredentials", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      signalAllAcceptedCredentialsChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let relyingPartyIdArg = args[0] as! String
+        let userIdArg = args[1] as! String
+        let allAcceptedCredentialIdsArg = args[2] as! [String]
+        api.signalAllAcceptedCredentials(relyingPartyId: relyingPartyIdArg, userId: userIdArg, allAcceptedCredentialIds: allAcceptedCredentialIdsArg) { result in
+          switch result {
+            case .success:
+              reply(wrapResult(nil))
+            case .failure(let error):
+              reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      signalAllAcceptedCredentialsChannel.setMessageHandler(nil)
     }
   }
 }

--- a/packages/passkeys/passkeys_darwin/lib/messages.g.dart
+++ b/packages/passkeys/passkeys_darwin/lib/messages.g.dart
@@ -441,4 +441,65 @@ class PasskeysApi {
       return;
     }
   }
+
+  Future<void> signalUnknownCredential(
+    String arg_relyingPartyId,
+    String arg_credentialId,
+  ) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+      'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.signalUnknownCredential',
+      codec,
+      binaryMessenger: _binaryMessenger,
+    );
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_relyingPartyId, arg_credentialId])
+            as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> signalAllAcceptedCredentials(
+    String arg_relyingPartyId,
+    String arg_userId,
+    List<String?> arg_allAcceptedCredentialIds,
+  ) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+      'dev.flutter.pigeon.passkeys_darwin.PasskeysApi.signalAllAcceptedCredentials',
+      codec,
+      binaryMessenger: _binaryMessenger,
+    );
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[
+              arg_relyingPartyId,
+              arg_userId,
+              arg_allAcceptedCredentialIds,
+            ])
+            as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
 }

--- a/packages/passkeys/passkeys_darwin/lib/passkeys_darwin.dart
+++ b/packages/passkeys/passkeys_darwin/lib/passkeys_darwin.dart
@@ -105,6 +105,27 @@ class PasskeysDarwin extends PasskeysPlatform {
       _api.cancelCurrentAuthenticatorOperation();
 
   @override
+  Future<void> signalUnknownCredential(
+    SignalUnknownCredentialRequestType request,
+  ) {
+    return _api.signalUnknownCredential(
+      request.relyingPartyId,
+      request.credentialId,
+    );
+  }
+
+  @override
+  Future<void> signalAllAcceptedCredentials(
+    SignalAllAcceptedCredentialsRequestType request,
+  ) {
+    return _api.signalAllAcceptedCredentials(
+      request.relyingPartyId,
+      request.userId,
+      request.allAcceptedCredentialIds,
+    );
+  }
+
+  @override
   Future<AvailabilityTypeIOS> getAvailability() async {
     final availability = await _api.canAuthenticate();
     final hasBiometrics = await _api.hasBiometrics();

--- a/packages/passkeys/passkeys_darwin/pigeons/messages.dart
+++ b/packages/passkeys/passkeys_darwin/pigeons/messages.dart
@@ -5,7 +5,7 @@ import 'package:pigeon/pigeon.dart';
 @ConfigurePigeon(
   PigeonOptions(
     dartOut: 'lib/messages.g.dart',
-    swiftOut: 'darwin/Classes/messages.swift',
+    swiftOut: 'darwin/passkeys_darwin/Sources/passkeys_darwin/messages.swift',
   ),
 )
 class RelyingParty {
@@ -147,4 +147,14 @@ abstract class PasskeysApi {
 
   @async
   void cancelCurrentAuthenticatorOperation();
+
+  @async
+  void signalUnknownCredential(String relyingPartyId, String credentialId);
+
+  @async
+  void signalAllAcceptedCredentials(
+    String relyingPartyId,
+    String userId,
+    List<String> allAcceptedCredentialIds,
+  );
 }

--- a/packages/passkeys/passkeys_darwin/test/passkeys_darwin_test.dart
+++ b/packages/passkeys/passkeys_darwin/test/passkeys_darwin_test.dart
@@ -7,6 +7,29 @@ import 'package:passkeys_platform_interface/types/types.dart';
 class _FakePasskeysApi extends pigeon.PasskeysApi {
   String? registerSalt;
   String? authenticateSalt;
+  List<Object?>? signalUnknownCredentialArgs;
+  List<Object?>? signalAllAcceptedCredentialsArgs;
+
+  @override
+  Future<void> signalUnknownCredential(
+    String relyingPartyId,
+    String credentialId,
+  ) async {
+    signalUnknownCredentialArgs = [relyingPartyId, credentialId];
+  }
+
+  @override
+  Future<void> signalAllAcceptedCredentials(
+    String relyingPartyId,
+    String userId,
+    List<String?> allAcceptedCredentialIds,
+  ) async {
+    signalAllAcceptedCredentialsArgs = [
+      relyingPartyId,
+      userId,
+      allAcceptedCredentialIds,
+    ];
+  }
 
   @override
   Future<pigeon.RegisterResponse> register(
@@ -127,6 +150,39 @@ void main() {
         response.clientExtensionResults?['prf'],
         isA<Map<dynamic, dynamic>>(),
       );
+    });
+
+    test('signalUnknownCredential forwards its arguments', () async {
+      final api = _FakePasskeysApi();
+      final platform = PasskeysDarwin(api: api);
+
+      await platform.signalUnknownCredential(
+        const SignalUnknownCredentialRequestType(
+          relyingPartyId: 'example.com',
+          credentialId: 'credential-id',
+        ),
+      );
+
+      expect(api.signalUnknownCredentialArgs, ['example.com', 'credential-id']);
+    });
+
+    test('signalAllAcceptedCredentials forwards its arguments', () async {
+      final api = _FakePasskeysApi();
+      final platform = PasskeysDarwin(api: api);
+
+      await platform.signalAllAcceptedCredentials(
+        const SignalAllAcceptedCredentialsRequestType(
+          relyingPartyId: 'example.com',
+          userId: 'user-id',
+          allAcceptedCredentialIds: ['cred-1', 'cred-2'],
+        ),
+      );
+
+      expect(api.signalAllAcceptedCredentialsArgs, [
+        'example.com',
+        'user-id',
+        ['cred-1', 'cred-2'],
+      ]);
     });
   });
 }

--- a/packages/passkeys/passkeys_platform_interface/lib/passkey_authenticator_interface.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/passkey_authenticator_interface.dart
@@ -16,4 +16,18 @@ abstract interface class PasskeyAuthenticatorInterface {
   Future<AuthenticateResponseType> authenticate(
     AuthenticateRequestType request,
   );
+
+  /// Signals to the platform that the credential in [request] is no longer
+  /// recognized by the relying party, so it can be removed from the credential
+  /// picker and autofill suggestions.
+  Future<void> signalUnknownCredential(
+    SignalUnknownCredentialRequestType request,
+  );
+
+  /// Signals to the platform the complete set of credentials that the relying
+  /// party still accepts for a user, so any others can be pruned from the
+  /// credential picker.
+  Future<void> signalAllAcceptedCredentials(
+    SignalAllAcceptedCredentialsRequestType request,
+  );
 }

--- a/packages/passkeys/passkeys_platform_interface/lib/passkeys_platform_interface.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/passkeys_platform_interface.dart
@@ -60,4 +60,26 @@ abstract class PasskeysPlatform extends PlatformInterface {
   /// Retrieves the availability information for passkeys, user-verifying
   /// platform authenticators, and conditional mediation whenever possible
   Future<AvailabilityType> getAvailability();
+
+  /// Signals to the platform that the credential in [request] is no longer
+  /// recognized by the relying party. Platforms that support the WebAuthn
+  /// Signal API can use this hint to remove the credential from the credential
+  /// picker and autofill suggestions.
+  ///
+  /// This is a best-effort hint; platforms without support treat it as a
+  /// no-op.
+  Future<void> signalUnknownCredential(
+    SignalUnknownCredentialRequestType request,
+  ) async {}
+
+  /// Signals to the platform the complete set of credentials that the relying
+  /// party still accepts for a user. Platforms that support the WebAuthn Signal
+  /// API can use this to prune any other credentials from the credential
+  /// picker.
+  ///
+  /// This is a best-effort hint; platforms without support treat it as a
+  /// no-op.
+  Future<void> signalAllAcceptedCredentials(
+    SignalAllAcceptedCredentialsRequestType request,
+  ) async {}
 }

--- a/packages/passkeys/passkeys_platform_interface/lib/types/signal_request.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/signal_request.dart
@@ -1,0 +1,44 @@
+/// The [SignalUnknownCredentialRequestType] is used to tell the platform that a
+/// credential is no longer recognized by the relying party, so that it can be
+/// removed from the credential picker and autofill suggestions.
+///
+/// This wraps the WebAuthn `PublicKeyCredential.signalUnknownCredential()`
+/// signal.
+class SignalUnknownCredentialRequestType {
+  /// Constructs a new instance.
+  const SignalUnknownCredentialRequestType({
+    required this.relyingPartyId,
+    required this.credentialId,
+  });
+
+  /// The relying party ID the credential belongs to.
+  final String relyingPartyId;
+
+  /// The Base64URL encoded ID of the credential that is no longer recognized.
+  final String credentialId;
+}
+
+/// The [SignalAllAcceptedCredentialsRequestType] is used to tell the platform
+/// the complete set of credential IDs that the relying party still accepts for
+/// a given user, so that any others can be pruned from the credential picker.
+///
+/// This wraps the WebAuthn `PublicKeyCredential.signalAllAcceptedCredentials()`
+/// signal.
+class SignalAllAcceptedCredentialsRequestType {
+  /// Constructs a new instance.
+  const SignalAllAcceptedCredentialsRequestType({
+    required this.relyingPartyId,
+    required this.userId,
+    required this.allAcceptedCredentialIds,
+  });
+
+  /// The relying party ID the credentials belong to.
+  final String relyingPartyId;
+
+  /// The Base64URL encoded ID of the user the credentials belong to.
+  final String userId;
+
+  /// The Base64URL encoded IDs of all credentials that are still accepted by
+  /// the relying party for this user.
+  final List<String> allAcceptedCredentialIds;
+}

--- a/packages/passkeys/passkeys_platform_interface/lib/types/types.dart
+++ b/packages/passkeys/passkeys_platform_interface/lib/types/types.dart
@@ -6,4 +6,5 @@ export 'mediation.dart';
 export 'register_request.dart';
 export 'register_response.dart';
 export 'relying_party.dart';
+export 'signal_request.dart';
 export 'user.dart';

--- a/packages/passkeys/passkeys_web/lib/interop.dart
+++ b/packages/passkeys/passkeys_web/lib/interop.dart
@@ -30,3 +30,16 @@ external JSPromise<JSBoolean?> isConditionalMediationAvailable();
 /// Whether the current browser supports passkeys.
 @JS('PasskeyAuthenticator.hasPasskeySupport')
 external JSBoolean hasPasskeySupport();
+
+/// The global `PublicKeyCredential` interface. Used to feature-detect the
+/// WebAuthn Signal API static methods before calling them.
+@JS('PublicKeyCredential')
+external JSObject? get publicKeyCredential;
+
+/// Signals that a credential is no longer recognized by the relying party.
+@JS('PublicKeyCredential.signalUnknownCredential')
+external JSPromise<JSAny?> signalUnknownCredentialJS(JSObject options);
+
+/// Signals the complete set of credentials the relying party still accepts.
+@JS('PublicKeyCredential.signalAllAcceptedCredentials')
+external JSPromise<JSAny?> signalAllAcceptedCredentialsJS(JSObject options);

--- a/packages/passkeys/passkeys_web/lib/passkeys_web.dart
+++ b/packages/passkeys/passkeys_web/lib/passkeys_web.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
@@ -113,6 +114,59 @@ class PasskeysWeb extends PasskeysPlatform {
         details: exception,
       );
     }
+  }
+
+  @override
+  Future<void> signalUnknownCredential(
+    SignalUnknownCredentialRequestType request,
+  ) async {
+    if (!_supportsSignal('signalUnknownCredential')) {
+      // This browser does not support the Signal API; the hint is best-effort
+      // so treat it as a no-op.
+      return;
+    }
+
+    final options = JSObject()
+      ..setProperty('rpId'.toJS, request.relyingPartyId.toJS)
+      ..setProperty('credentialId'.toJS, request.credentialId.toJS);
+
+    try {
+      await signalUnknownCredentialJS(options).toDart;
+    } catch (e) {
+      throw _parseException(e.toString());
+    }
+  }
+
+  @override
+  Future<void> signalAllAcceptedCredentials(
+    SignalAllAcceptedCredentialsRequestType request,
+  ) async {
+    if (!_supportsSignal('signalAllAcceptedCredentials')) {
+      // This browser does not support the Signal API; the hint is best-effort
+      // so treat it as a no-op.
+      return;
+    }
+
+    final credentialIds = request.allAcceptedCredentialIds
+        .map((e) => e.toJS)
+        .toList()
+        .toJS;
+    final options = JSObject()
+      ..setProperty('rpId'.toJS, request.relyingPartyId.toJS)
+      ..setProperty('userId'.toJS, request.userId.toJS)
+      ..setProperty('allAcceptedCredentialIds'.toJS, credentialIds);
+
+    try {
+      await signalAllAcceptedCredentialsJS(options).toDart;
+    } catch (e) {
+      throw _parseException(e.toString());
+    }
+  }
+
+  bool _supportsSignal(String method) {
+    final publicKeyCredentialCtor = publicKeyCredential;
+    return publicKeyCredentialCtor != null &&
+        publicKeyCredentialCtor.has(method);
   }
 
   @override


### PR DESCRIPTION
## Summary

Implements #231 by exposing WebAuthn Level 3's Signal API on `PasskeyAuthenticator`:

- `signalUnknownCredential({ rpId, credentialId })` — tells the platform a credential is no longer recognized so it can be removed from the passkey picker / autofill.
- `signalAllAcceptedCredentials({ rpId, userId, allAcceptedCredentialIds })` — tells the platform the full set of credentials still valid for a user so others can be pruned.

This lets apps clean up passkeys that were deleted server-side (the problem from #172), which previously had no programmatic remedy.

The original blocker (waiting for `androidx.credentials` 1.6.0 to leave beta) is resolved now that 1.6.0 is stable.

## Changes per package

- **`passkeys_platform_interface`**: new `SignalUnknownCredentialRequestType` / `SignalAllAcceptedCredentialsRequestType`, plus methods on the interface and platform base. The platform-base default is a best-effort **no-op**, so unsupported platforms simply do nothing.
- **`passkeys`**: public API on `PasskeyAuthenticator` with base64url validation and `PlatformException` mapping.
- **`passkeys_android`**: bumped `androidx.credentials` `1.3.0` → `1.6.0` and `compileSdk` `34` → `35` (required by 1.6.0); implemented via `CredentialManager.signalCredentialStateAsync(...)`.
- **`passkeys_darwin`**: implemented via `ASCredentialDataManager.report…PublicKeyCredential(...)`, gated behind `if #available(iOS 26.2, macOS 26.2, *)`; older OS versions are a no-op.
- **`passkeys_web`**: binds the browser `PublicKeyCredential.signal*` static methods directly, feature-detected (no bundle rebuild required).
- **`passkeys_windows`**: inherits the no-op default.

## Verification

- `melos format`, `melos analyze --fatal-infos`, `melos test` all pass (added forwarding tests for Android + Darwin).
- Example **Android APK** and **web** builds pass.

## Notes for reviewers

- **iOS/macOS build requirement**: `ASCredentialDataManager` only exists in the Xcode 26.x SDK, so building the Apple side now requires that toolchain (runtime is gated to 26.2+). Not compile-verified on Apple here (no full Xcode available in the dev environment).
- **Pigeon version**: the pubspecs pin `pigeon ^26.3.4`, but all committed generated files were produced with **v11.0.1**. I regenerated with v11.0.1 to keep the diff minimal and avoid breaking the hand-written native glue that a v26 regen would require (`setup`→`setUp`, `Result<Void>`→`VoidResult`). A migration to v26 would be a good separate PR.

Closes #231