### PR TITLE
docs: fix mistakes across package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Flutter packages to enable passkey authentication (based on WebAuthn / FIDO2).
 #### Description
 
 A Flutter package that enables simple passkey authentication.
-Currently Android and iOS are supported.
+Currently Android, iOS, macOS, Web and Windows are supported.
 
 #### Features
 

--- a/packages/passkeys/passkeys/README.md
+++ b/packages/passkeys/passkeys/README.md
@@ -13,7 +13,7 @@ on Vercel).
 
 ## Features
 
-- sign up and login users with passkeys on iOS, Android and Web
+- sign up and login users with passkeys on Android, iOS, macOS, Web and Windows
 - login users with conditional UI
 - derive secrets from a passkey through the WebAuthn PRF extension (see [Using the PRF extension](#using-the-prf-extension))
 
@@ -409,7 +409,7 @@ If you get an error like "Simulator requires enrolled biometrics to use passkeys
 login, activate Face ID for your device.
 On a simulator, this can be done under _Features_ => _Face ID_ by clicking on "Enrolled".
 
-<img src="https://raw.githubusercontent.com/corbado/flutter-passkeys/main/packages/passkeys/passkeys/doc/ios_error_enrolled_biometrics.png" style="width: 200px" calt="ios_enrolled_biometrics">
+<img src="https://raw.githubusercontent.com/corbado/flutter-passkeys/main/packages/passkeys/passkeys/doc/ios_error_enrolled_biometrics.png" style="width: 200px" alt="ios_enrolled_biometrics">
 </details>
 
 ### macOS
@@ -429,7 +429,7 @@ On a simulator, this can be done under _Features_ => _Face ID_ by clicking on "E
 <details>
 <summary>1. Update your index.html to include our JavaScript library</summary>
 Our passkeys_web package relies on JavaScript for integrating with the browser's WebAuthn API.
-To make this work, you have to include our JavaScript library in your web/index.html file. If not correctly integrated the PasskeyAuthenticator would not correctly initialize and the application would crash and an exception asking to add the code blow will show in your console.
+To make this work, you have to include our JavaScript library in your web/index.html file. If not correctly integrated the PasskeyAuthenticator would not correctly initialize and the application would crash and an exception asking to add the code below will show in your console.
 
 ```html
 <script

--- a/packages/passkeys/passkeys/example/README.md
+++ b/packages/passkeys/passkeys/example/README.md
@@ -32,7 +32,7 @@ If you change the development team id you will get an error on sign up/sign in
 because the relying party server in the example only trusts apps that have been built with a
 development team id of "0000000000" and a Bundle Identifier of "com.corbado.passkeys.pub".
 
-<img src="https://raw.githubusercontent.com/corbado/flutter-passkeys/main/packages/passkeys/passkeys/doc/xcode-team-unknown-name.png" style="width: 50%" calt="ios_enrolled_biometrics">
+<img src="https://raw.githubusercontent.com/corbado/flutter-passkeys/main/packages/passkeys/passkeys/doc/xcode-team-unknown-name.png" style="width: 50%" alt="xcode_team_unknown_name">
 
 
 ### macOS

--- a/packages/passkeys/passkeys_doctor/README.md
+++ b/packages/passkeys/passkeys_doctor/README.md
@@ -6,7 +6,7 @@ This is an internal package and it is used inside of the passkeys package
 
 ## Usage
 
-The doctor is unabled by default in the example.
+The doctor is enabled by default in the example.
 
 Here is what the doctor checks for
 
@@ -33,7 +33,7 @@ Here is what the doctor checks for
 
 ### 3. Error Handling
 
-The doctor keeps track of errors and exceptions happening in the passkeys flows , give a description of it and suggestions on how to fix them.
+The doctor keeps track of errors and exceptions happening in the passkeys flows, gives a description of them and suggestions on how to fix them.
 
 
 > **Note:** The doctor can export the results from the exception and the checks through a result Stream that can be used in the UI as done in the example

--- a/packages/passkeys/passkeys_windows/README.md
+++ b/packages/passkeys/passkeys_windows/README.md
@@ -1,4 +1,4 @@
-# passkeys_darwin
+# passkeys_windows
 
 The Windows implementation of `passkeys`.
 


### PR DESCRIPTION
## Summary

Fixes typos and factual mistakes found while reviewing all package READMEs.

- **passkeys_doctor**: `unabled` → `enabled` (the example initializes `PasskeyAuthenticator(debugMode: true)`, so the doctor is on by default there); fixed a stray space and subject-verb agreement in the error-handling description.
- **passkeys_windows**: title said `# passkeys_darwin` (copy-paste leftover) → `# passkeys_windows`.
- **passkeys**: fixed invalid `calt=` image attribute → `alt=`; `code blow` → `code below`; feature list now matches the support table (Android, iOS, macOS, Web and Windows).
- **passkeys example**: fixed invalid `calt=` attribute and wrong alt text copied from another image.
- **root README**: "Currently Android and iOS are supported." contradicted the support table directly above it → now lists all supported platforms.

## Test plan

Documentation-only change, no code affected.