### PR TITLE
refactor: clean up analysis lints and refine auth exception types

### DIFF
--- a/packages/corbado_auth/example/lib/pages/edit_profile_page.dart
+++ b/packages/corbado_auth/example/lib/pages/edit_profile_page.dart
@@ -103,7 +103,7 @@ class EditProfilePage extends HookConsumerWidget {
                           leading: const Icon(Icons.check, color: Colors.green),
                           background: Theme.of(context).colorScheme.primary,
                         );
-                      } on CorbadoError catch (e) {
+                      } on CorbadoAuthException catch (e) {
                         error.value = e.translatedError;
                       } catch (e) {
                         error.value = e.toString();

--- a/packages/corbado_auth/example/lib/pages/passkey_list_page.dart
+++ b/packages/corbado_auth/example/lib/pages/passkey_list_page.dart
@@ -85,7 +85,7 @@ class PasskeyListPage extends HookConsumerWidget {
                                     context,
                                   ).colorScheme.primary,
                                 );
-                              } on CorbadoError catch (e) {
+                              } on CorbadoAuthException catch (e) {
                                 error.value = e.translatedError;
                               } catch (e) {
                                 error.value = e.toString();
@@ -124,7 +124,7 @@ class PasskeyListPage extends HookConsumerWidget {
                           leading: const Icon(Icons.check, color: Colors.green),
                           background: Theme.of(context).colorScheme.primary,
                         );
-                      } on CorbadoError catch (e) {
+                      } on CorbadoAuthException catch (e) {
                         error.value = e.translatedError;
                       } catch (e) {
                         error.value = e.toString();

--- a/packages/corbado_auth/lib/src/blocks/email_verify_block.dart
+++ b/packages/corbado_auth/lib/src/blocks/email_verify_block.dart
@@ -1,11 +1,9 @@
-// ignore_for_file: library_prefixes, avoid_positional_boolean_parameters
-
 import 'package:corbado_auth/src/blocks/translator.dart';
 import 'package:corbado_auth/src/blocks/types.dart';
 import 'package:corbado_auth/src/services/telemetry/telemetry.dart';
 import 'package:corbado_auth/src/types/screen_names.dart';
 import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart'
-    as Api;
+    as api;
 
 /// The method used to verify an email address.
 enum VerificationMethod {
@@ -26,12 +24,12 @@ class EmailVerifyBlockData {
     required this.isPostLoginVerification,
   });
 
-  /// Builds the data from a server [Api.GeneralBlockVerifyIdentifier] response.
+  /// Builds the data from a server [api.GeneralBlockVerifyIdentifier] response.
   factory EmailVerifyBlockData.fromProcessResponse(
-    Api.GeneralBlockVerifyIdentifier typed,
+    api.GeneralBlockVerifyIdentifier typed,
   ) {
     final verificationMethod =
-        typed.verificationMethod == Api.VerificationMethod.emailOtp
+        typed.verificationMethod == api.VerificationMethod.emailOtp
         ? VerificationMethod.emailOTP
         : VerificationMethod.emailLink;
 
@@ -72,12 +70,12 @@ class EmailVerifyBlock extends Block<EmailVerifyBlockData> {
   EmailVerifyBlock({
     required super.processHandler,
     required super.data,
-    required Api.AuthType authType,
+    required api.AuthType authType,
   }) : super(
-         type: Api.BlockType.emailVerify,
+         type: api.BlockType.emailVerify,
          alternatives: [],
          initialScreen: ScreenNames.EmailVerifyOTP,
-         authProcessType: authType == Api.AuthType.login
+         authProcessType: authType == api.AuthType.login
              ? AuthProcessType.Login
              : AuthProcessType.Signup,
        );
@@ -127,7 +125,7 @@ class EmailVerifyBlock extends Block<EmailVerifyBlockData> {
 
       final res = await corbadoService.verifyEmailOtpCode(otpCode);
       processHandler.updateBlockFromServer(res);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       data.primaryLoading = false;
       processHandler.updateBlockFromError(e);
     }
@@ -152,7 +150,7 @@ class EmailVerifyBlock extends Block<EmailVerifyBlockData> {
 
         return;
       }
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       processHandler.updateBlockFromError(e);
     }
   }
@@ -166,8 +164,7 @@ class EmailVerifyBlock extends Block<EmailVerifyBlockData> {
 
     try {
       if (newValue == data.email) {
-        // ignore: only_throw_errors
-        throw CorbadoError(
+        throw CorbadoAuthException(
           errorCode: 'new_identifier_same_as_old',
           translatedError: Translator.error('new_identifier_same_as_old'),
         );
@@ -178,18 +175,17 @@ class EmailVerifyBlock extends Block<EmailVerifyBlockData> {
 
       final res = await corbadoService.updateEmail(newValue);
 
-      final error = CorbadoError.fromRequestError(res.blockBody.error);
+      final error = CorbadoAuthException.fromRequestError(res.blockBody.error);
 
       if (error != null) {
         data.primaryLoading = false;
 
-        // ignore: only_throw_errors
         throw error;
       }
 
       await resendEmail();
       navigateToVerifyEmail();
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       data.primaryLoading = false;
       processHandler.updateBlockFromError(e);
     }

--- a/packages/corbado_auth/lib/src/blocks/email_verify_block.dart
+++ b/packages/corbado_auth/lib/src/blocks/email_verify_block.dart
@@ -3,16 +3,23 @@ import 'package:corbado_auth/src/blocks/types.dart';
 import 'package:corbado_auth/src/services/telemetry/telemetry.dart';
 import 'package:corbado_auth/src/types/screen_names.dart';
 import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart'
-    as api;
+    hide VerificationMethod;
+import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart'
+    as api
+    show VerificationMethod;
 
 /// The method used to verify an email address.
-enum VerificationMethod {
+enum EmailVerificationMethod {
   /// Verification via a one-time password sent by email.
   emailOTP,
 
   /// Verification via a magic link sent by email.
   emailLink,
 }
+
+/// Deprecated alias for [EmailVerificationMethod].
+@Deprecated('Use EmailVerificationMethod instead.')
+typedef VerificationMethod = EmailVerificationMethod;
 
 /// Data backing the email verification step of an authentication process.
 class EmailVerifyBlockData {
@@ -24,14 +31,14 @@ class EmailVerifyBlockData {
     required this.isPostLoginVerification,
   });
 
-  /// Builds the data from a server [api.GeneralBlockVerifyIdentifier] response.
+  /// Builds the data from a server [GeneralBlockVerifyIdentifier] response.
   factory EmailVerifyBlockData.fromProcessResponse(
-    api.GeneralBlockVerifyIdentifier typed,
+    GeneralBlockVerifyIdentifier typed,
   ) {
     final verificationMethod =
         typed.verificationMethod == api.VerificationMethod.emailOtp
-        ? VerificationMethod.emailOTP
-        : VerificationMethod.emailLink;
+        ? EmailVerificationMethod.emailOTP
+        : EmailVerificationMethod.emailLink;
 
     DateTime? retryNotBefore;
     if (typed.retryNotBefore != null) {
@@ -52,7 +59,7 @@ class EmailVerifyBlockData {
   final String email;
 
   /// The verification method to use for this email.
-  final VerificationMethod verificationMethod;
+  final EmailVerificationMethod verificationMethod;
 
   /// The earliest time at which a verification can be retried.
   DateTime? retryNotBefore;
@@ -70,12 +77,12 @@ class EmailVerifyBlock extends Block<EmailVerifyBlockData> {
   EmailVerifyBlock({
     required super.processHandler,
     required super.data,
-    required api.AuthType authType,
+    required AuthType authType,
   }) : super(
-         type: api.BlockType.emailVerify,
+         type: BlockType.emailVerify,
          alternatives: [],
          initialScreen: ScreenNames.EmailVerifyOTP,
-         authProcessType: authType == api.AuthType.login
+         authProcessType: authType == AuthType.login
              ? AuthProcessType.Login
              : AuthProcessType.Signup,
        );
@@ -105,7 +112,7 @@ class EmailVerifyBlock extends Block<EmailVerifyBlockData> {
 
     error = null;
 
-    if (data.verificationMethod == VerificationMethod.emailOTP) {
+    if (data.verificationMethod == EmailVerificationMethod.emailOTP) {
       processHandler.updateCurrentScreen(ScreenNames.EmailVerifyOTP);
     } else {
       processHandler.updateCurrentScreen(ScreenNames.EmailVerifyOTP);
@@ -139,7 +146,7 @@ class EmailVerifyBlock extends Block<EmailVerifyBlockData> {
     );
 
     try {
-      if (data.verificationMethod == VerificationMethod.emailOTP) {
+      if (data.verificationMethod == EmailVerificationMethod.emailOTP) {
         final res = await corbadoService.sendEmailOtpCode();
         processHandler.updateBlockFromServer(res);
 

--- a/packages/corbado_auth/lib/src/blocks/login_init_block.dart
+++ b/packages/corbado_auth/lib/src/blocks/login_init_block.dart
@@ -20,7 +20,9 @@ class LoginInitBlockData {
   factory LoginInitBlockData.fromProcessResponse(GeneralBlockLoginInit typed) {
     return LoginInitBlockData(
       loginIdentifier: typed.identifierValue,
-      loginIdentifierError: CorbadoError.fromRequestError(typed.fieldError),
+      loginIdentifierError: CorbadoAuthException.fromRequestError(
+        typed.fieldError,
+      ),
       conditionalUIChallenge: typed.conditionalUIChallenge,
       isPhoneFocused: typed.isPhone,
       emailEnabled: typed.isEmailAvailable,
@@ -33,7 +35,7 @@ class LoginInitBlockData {
   final String loginIdentifier;
 
   /// The validation error for the login identifier, if any.
-  final CorbadoError? loginIdentifierError;
+  final CorbadoAuthException? loginIdentifierError;
 
   /// The challenge used to start conditional UI, if available.
   final String? conditionalUIChallenge;
@@ -101,7 +103,7 @@ class LoginInitBlock extends Block<LoginInitBlockData> {
 
       final response = await corbadoService.loginInit(loginIdentifier, isPhone);
       processHandler.updateBlockFromServer(response);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       data.primaryLoading = false;
       processHandler.updateBlockFromError(e);
     }
@@ -126,7 +128,7 @@ class LoginInitBlock extends Block<LoginInitBlockData> {
         true,
       );
       processHandler.updateBlockFromServer(response);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       processHandler.updateBlockFromError(e);
     } on AuthenticatorException {
       // all authenticator exceptions that have not been translated to errors

--- a/packages/corbado_auth/lib/src/blocks/passkey_append_block.dart
+++ b/packages/corbado_auth/lib/src/blocks/passkey_append_block.dart
@@ -1,7 +1,7 @@
 import 'package:corbado_auth/corbado_auth.dart';
 import 'package:corbado_auth/src/services/telemetry/telemetry.dart';
 import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart'
-    as api;
+    hide VerificationMethod;
 
 /// Data backing the passkey append step of an authentication process.
 class PasskeyAppendBlockData {
@@ -15,9 +15,9 @@ class PasskeyAppendBlockData {
     this.preferredFallback,
   });
 
-  /// Builds the data from a server [api.GeneralBlockPasskeyAppend] response.
+  /// Builds the data from a server [GeneralBlockPasskeyAppend] response.
   factory PasskeyAppendBlockData.fromProcessResponse(
-    api.GeneralBlockPasskeyAppend typed,
+    GeneralBlockPasskeyAppend typed,
   ) {
     return PasskeyAppendBlockData(
       availableFallbacks: [],
@@ -37,7 +37,7 @@ class PasskeyAppendBlockData {
   final String identifierValue;
 
   /// The type of the identifier value.
-  final api.LoginIdentifierType identifierType;
+  final LoginIdentifierType identifierType;
 
   /// The fallback that should be used by default, if any.
   PasskeyFallback? preferredFallback;
@@ -55,12 +55,12 @@ class PasskeyAppendBlock extends Block<PasskeyAppendBlockData> {
   PasskeyAppendBlock({
     required super.processHandler,
     required super.data,
-    required api.AuthType authType,
+    required AuthType authType,
   }) : super(
          initialScreen: ScreenNames.PasskeyAppend,
-         type: api.BlockType.passkeyAppend,
+         type: BlockType.passkeyAppend,
          alternatives: [],
-         authProcessType: authType == api.AuthType.login
+         authProcessType: authType == AuthType.login
              ? AuthProcessType.Login
              : AuthProcessType.Signup,
        );
@@ -68,17 +68,17 @@ class PasskeyAppendBlock extends Block<PasskeyAppendBlockData> {
   @override
   void init() {
     const allowedAlternatives = [
-      api.BlockType.emailVerify,
-      api.BlockType.phoneVerify,
+      BlockType.emailVerify,
+      BlockType.phoneVerify,
     ];
     data.availableFallbacks = alternatives
         .where((alternative) => allowedAlternatives.contains(alternative.type))
         .map((alternative) {
           return switch (alternative.type) {
-            api.BlockType.emailVerify
+            BlockType.emailVerify
                 when (alternative.data as EmailVerifyBlockData)
                         .verificationMethod !=
-                    VerificationMethod.emailLink =>
+                    EmailVerificationMethod.emailLink =>
               PasskeyFallback(
                 label: 'Email verification',
                 onTap: initFallbackEmailOtp,
@@ -95,7 +95,7 @@ class PasskeyAppendBlock extends Block<PasskeyAppendBlockData> {
     };
 
     data.canBeSkipped = alternatives.any(
-      (a) => a.type == api.BlockType.completed,
+      (a) => a.type == BlockType.completed,
     );
 
     // depending on data.canBeSkipped is only a short term fix

--- a/packages/corbado_auth/lib/src/blocks/passkey_append_block.dart
+++ b/packages/corbado_auth/lib/src/blocks/passkey_append_block.dart
@@ -1,9 +1,7 @@
-// ignore_for_file: library_prefixes
-
 import 'package:corbado_auth/corbado_auth.dart';
 import 'package:corbado_auth/src/services/telemetry/telemetry.dart';
 import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart'
-    as Api;
+    as api;
 
 /// Data backing the passkey append step of an authentication process.
 class PasskeyAppendBlockData {
@@ -17,9 +15,9 @@ class PasskeyAppendBlockData {
     this.preferredFallback,
   });
 
-  /// Builds the data from a server [Api.GeneralBlockPasskeyAppend] response.
+  /// Builds the data from a server [api.GeneralBlockPasskeyAppend] response.
   factory PasskeyAppendBlockData.fromProcessResponse(
-    Api.GeneralBlockPasskeyAppend typed,
+    api.GeneralBlockPasskeyAppend typed,
   ) {
     return PasskeyAppendBlockData(
       availableFallbacks: [],
@@ -39,7 +37,7 @@ class PasskeyAppendBlockData {
   final String identifierValue;
 
   /// The type of the identifier value.
-  final Api.LoginIdentifierType identifierType;
+  final api.LoginIdentifierType identifierType;
 
   /// The fallback that should be used by default, if any.
   PasskeyFallback? preferredFallback;
@@ -57,12 +55,12 @@ class PasskeyAppendBlock extends Block<PasskeyAppendBlockData> {
   PasskeyAppendBlock({
     required super.processHandler,
     required super.data,
-    required Api.AuthType authType,
+    required api.AuthType authType,
   }) : super(
          initialScreen: ScreenNames.PasskeyAppend,
-         type: Api.BlockType.passkeyAppend,
+         type: api.BlockType.passkeyAppend,
          alternatives: [],
-         authProcessType: authType == Api.AuthType.login
+         authProcessType: authType == api.AuthType.login
              ? AuthProcessType.Login
              : AuthProcessType.Signup,
        );
@@ -70,14 +68,14 @@ class PasskeyAppendBlock extends Block<PasskeyAppendBlockData> {
   @override
   void init() {
     const allowedAlternatives = [
-      Api.BlockType.emailVerify,
-      Api.BlockType.phoneVerify,
+      api.BlockType.emailVerify,
+      api.BlockType.phoneVerify,
     ];
     data.availableFallbacks = alternatives
         .where((alternative) => allowedAlternatives.contains(alternative.type))
         .map((alternative) {
           return switch (alternative.type) {
-            Api.BlockType.emailVerify
+            api.BlockType.emailVerify
                 when (alternative.data as EmailVerifyBlockData)
                         .verificationMethod !=
                     VerificationMethod.emailLink =>
@@ -97,7 +95,7 @@ class PasskeyAppendBlock extends Block<PasskeyAppendBlockData> {
     };
 
     data.canBeSkipped = alternatives.any(
-      (a) => a.type == Api.BlockType.completed,
+      (a) => a.type == api.BlockType.completed,
     );
 
     // depending on data.canBeSkipped is only a short term fix
@@ -120,7 +118,7 @@ class PasskeyAppendBlock extends Block<PasskeyAppendBlockData> {
 
       final response = await corbadoService.appendPasskey();
       processHandler.updateBlockFromServer(response);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       data.primaryLoading = false;
       processHandler.updateBlockFromError(e);
     }
@@ -136,7 +134,7 @@ class PasskeyAppendBlock extends Block<PasskeyAppendBlockData> {
     try {
       final response = await corbadoService.sendEmailOtpCode();
       processHandler.updateBlockFromServer(response);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       processHandler.updateBlockFromError(e);
     }
   }
@@ -151,7 +149,7 @@ class PasskeyAppendBlock extends Block<PasskeyAppendBlockData> {
     try {
       final response = await corbadoService.completeAuthProcess();
       processHandler.updateBlockFromServer(response);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       processHandler.updateBlockFromError(e);
     }
   }

--- a/packages/corbado_auth/lib/src/blocks/passkey_verify_block.dart
+++ b/packages/corbado_auth/lib/src/blocks/passkey_verify_block.dart
@@ -1,7 +1,7 @@
 import 'package:corbado_auth/corbado_auth.dart';
 import 'package:corbado_auth/src/services/telemetry/telemetry.dart';
 import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart'
-    as api;
+    hide VerificationMethod;
 
 /// Data backing the passkey verification step of an authentication process.
 class PasskeyVerifyBlockData {
@@ -12,9 +12,9 @@ class PasskeyVerifyBlockData {
     this.preferredFallback,
   });
 
-  /// Builds the data from a server [api.GeneralBlockPasskeyVerify] response.
+  /// Builds the data from a server [GeneralBlockPasskeyVerify] response.
   factory PasskeyVerifyBlockData.fromProcessResponse(
-    api.GeneralBlockPasskeyVerify typed,
+    GeneralBlockPasskeyVerify typed,
   ) {
     return PasskeyVerifyBlockData(
       availableFallbacks: [],
@@ -44,7 +44,7 @@ class PasskeyVerifyBlock extends Block<PasskeyVerifyBlockData> {
     required super.data,
   }) : super(
          initialScreen: ScreenNames.PasskeyVerify,
-         type: api.BlockType.passkeyVerify,
+         type: BlockType.passkeyVerify,
          alternatives: [],
          authProcessType: AuthProcessType.Login,
        );
@@ -53,10 +53,10 @@ class PasskeyVerifyBlock extends Block<PasskeyVerifyBlockData> {
   void init() {
     data.availableFallbacks = alternatives.map((alternative) {
       return switch (alternative.type) {
-        api.BlockType.emailVerify
+        BlockType.emailVerify
             when (alternative.data as EmailVerifyBlockData)
                     .verificationMethod !=
-                VerificationMethod.emailLink =>
+                EmailVerificationMethod.emailLink =>
           PasskeyFallback(
             label: 'Email verification',
             onTap: initFallbackEmailOtp,

--- a/packages/corbado_auth/lib/src/blocks/passkey_verify_block.dart
+++ b/packages/corbado_auth/lib/src/blocks/passkey_verify_block.dart
@@ -1,9 +1,7 @@
-// ignore_for_file: library_prefixes
-
 import 'package:corbado_auth/corbado_auth.dart';
 import 'package:corbado_auth/src/services/telemetry/telemetry.dart';
 import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart'
-    as Api;
+    as api;
 
 /// Data backing the passkey verification step of an authentication process.
 class PasskeyVerifyBlockData {
@@ -14,9 +12,9 @@ class PasskeyVerifyBlockData {
     this.preferredFallback,
   });
 
-  /// Builds the data from a server [Api.GeneralBlockPasskeyVerify] response.
+  /// Builds the data from a server [api.GeneralBlockPasskeyVerify] response.
   factory PasskeyVerifyBlockData.fromProcessResponse(
-    Api.GeneralBlockPasskeyVerify typed,
+    api.GeneralBlockPasskeyVerify typed,
   ) {
     return PasskeyVerifyBlockData(
       availableFallbacks: [],
@@ -46,7 +44,7 @@ class PasskeyVerifyBlock extends Block<PasskeyVerifyBlockData> {
     required super.data,
   }) : super(
          initialScreen: ScreenNames.PasskeyVerify,
-         type: Api.BlockType.passkeyVerify,
+         type: api.BlockType.passkeyVerify,
          alternatives: [],
          authProcessType: AuthProcessType.Login,
        );
@@ -55,7 +53,7 @@ class PasskeyVerifyBlock extends Block<PasskeyVerifyBlockData> {
   void init() {
     data.availableFallbacks = alternatives.map((alternative) {
       return switch (alternative.type) {
-        Api.BlockType.emailVerify
+        api.BlockType.emailVerify
             when (alternative.data as EmailVerifyBlockData)
                     .verificationMethod !=
                 VerificationMethod.emailLink =>
@@ -89,7 +87,7 @@ class PasskeyVerifyBlock extends Block<PasskeyVerifyBlockData> {
       final response = await corbadoService.verifyPasskey();
       data.primaryLoading = false;
       processHandler.updateBlockFromServer(response);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       data.primaryLoading = false;
       processHandler.updateBlockFromError(e);
     } on NoCredentialsAvailableException {
@@ -107,7 +105,7 @@ class PasskeyVerifyBlock extends Block<PasskeyVerifyBlockData> {
     try {
       final response = await corbadoService.sendEmailOtpCode();
       processHandler.updateBlockFromServer(response);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       processHandler.updateBlockFromError(e);
     }
   }

--- a/packages/corbado_auth/lib/src/blocks/signup_init_block.dart
+++ b/packages/corbado_auth/lib/src/blocks/signup_init_block.dart
@@ -16,7 +16,7 @@ class SignupInitBlockData {
     if (typed.fullName != null) {
       fullName = TextFieldWithError(
         value: typed.fullName!.fullName,
-        error: CorbadoError.fromRequestError(typed.fullName!.error),
+        error: CorbadoAuthException.fromRequestError(typed.fullName!.error),
       );
     }
 
@@ -25,7 +25,7 @@ class SignupInitBlockData {
       if (identifier.type == LoginIdentifierType.email) {
         email = TextFieldWithError(
           value: identifier.identifier,
-          error: CorbadoError.fromRequestErrorWithIdentifier(
+          error: CorbadoAuthException.fromRequestErrorWithIdentifier(
             identifier.error,
             identifier.type,
           ),
@@ -91,7 +91,7 @@ class SignupInitBlock extends Block<SignupInitBlockData> {
         fullName: fullName,
       );
       processHandler.updateBlockFromServer(res);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       data.primaryLoading = false;
       processHandler.updateBlockFromError(e);
     }

--- a/packages/corbado_auth/lib/src/blocks/types.dart
+++ b/packages/corbado_auth/lib/src/blocks/types.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: constant_identifier_names
-// ignore_for_file: prefer_constructors_over_static_methods
 
 import 'package:corbado_auth/corbado_auth.dart';
 import 'package:corbado_auth/src/blocks/translator.dart';
@@ -26,7 +25,7 @@ class TextFieldWithError {
   final String value;
 
   /// The validation error for the field, if any.
-  final CorbadoError? error;
+  final CorbadoAuthException? error;
 }
 
 /// A fallback verification option presented to the user.
@@ -42,35 +41,20 @@ class PasskeyFallback {
 }
 
 /// An error raised during a Corbado authentication process.
-class CorbadoError {
+@Deprecated(
+  'CorbadoError is misnamed for a recoverable, catchable condition. '
+  'Use CorbadoAuthException instead, which extends this type so existing '
+  '`on CorbadoError` catch clauses keep working.',
+)
+class CorbadoError implements Exception {
   /// Creates an error with an [errorCode], [translatedError] and optional
   /// [original] cause.
+  @Deprecated('Use CorbadoAuthException instead.')
   const CorbadoError({
     required this.errorCode,
     required this.translatedError,
     this.original,
   });
-
-  /// Creates an error representing a missing server response.
-  factory CorbadoError.fromMissingServerResponse() {
-    const code = 'missing_server_response';
-
-    return CorbadoError(
-      errorCode: code,
-      translatedError: Translator.error(code),
-    );
-  }
-
-  /// Creates an error representing an unknown error [e].
-  factory CorbadoError.fromUnknownError(Object e) {
-    const code = 'unknown_error';
-
-    return CorbadoError(
-      errorCode: code,
-      translatedError: Translator.error(code),
-      original: e,
-    );
-  }
 
   /// The machine readable error code.
   final String errorCode;
@@ -85,22 +69,72 @@ class CorbadoError {
   String detailedError() {
     return 'error ($errorCode): $original';
   }
+}
 
-  /// Creates an error from a server [RequestError], or null if there is none.
-  static CorbadoError? fromRequestError(RequestError? error) {
+/// An exception raised during a Corbado authentication process.
+// ignore: deprecated_member_use_from_same_package
+class CorbadoAuthException extends CorbadoError {
+  /// Creates an exception with an [errorCode], [translatedError] and optional
+  /// [original] cause.
+  const CorbadoAuthException({
+    required super.errorCode,
+    required super.translatedError,
+    super.original,
+  });
+
+  /// Creates an exception representing a missing server response.
+  factory CorbadoAuthException.fromMissingServerResponse() {
+    const code = 'missing_server_response';
+
+    return CorbadoAuthException(
+      errorCode: code,
+      translatedError: Translator.error(code),
+    );
+  }
+
+  /// Creates an exception representing an unknown error [e].
+  factory CorbadoAuthException.fromUnknownError(Object e) {
+    const code = 'unknown_error';
+
+    return CorbadoAuthException(
+      errorCode: code,
+      translatedError: Translator.error(code),
+      original: e,
+    );
+  }
+
+  /// Creates an exception from an authenticator exception [e].
+  factory CorbadoAuthException.fromAuthenticatorError(
+    AuthenticatorException e,
+  ) {
+    if (e is PasskeyAuthCancelledException) {
+      const errorCode = 'passkey_operation_cancelled';
+      return CorbadoAuthException(
+        errorCode: errorCode,
+        translatedError: Translator.error(errorCode),
+        original: e,
+      );
+    }
+
+    return CorbadoAuthException.fromUnknownError(e);
+  }
+
+  /// Creates an exception from a server [RequestError], or null if there is
+  /// none.
+  static CorbadoAuthException? fromRequestError(RequestError? error) {
     if (error == null) {
       return null;
     }
 
-    return CorbadoError(
+    return CorbadoAuthException(
       errorCode: error.code,
       translatedError: Translator.error(error.code),
     );
   }
 
-  /// Creates an error from a [RequestError] using identifier-specific
+  /// Creates an exception from a [RequestError] using identifier-specific
   /// translations, or null if there is none.
-  static CorbadoError? fromRequestErrorWithIdentifier(
+  static CorbadoAuthException? fromRequestErrorWithIdentifier(
     RequestError? error,
     LoginIdentifierType identifierType,
   ) {
@@ -113,24 +147,10 @@ class CorbadoError {
       identifierType,
     );
 
-    return CorbadoError(
+    return CorbadoAuthException(
       errorCode: error.code,
       translatedError: translatedError,
     );
-  }
-
-  /// Creates an error from an authenticator exception [e].
-  static CorbadoError fromAuthenticatorError(AuthenticatorException e) {
-    if (e is PasskeyAuthCancelledException) {
-      const errorCode = 'passkey_operation_cancelled';
-      return CorbadoError(
-        errorCode: errorCode,
-        translatedError: Translator.error(errorCode),
-        original: e,
-      );
-    }
-
-    return CorbadoError.fromUnknownError(e);
   }
 }
 
@@ -163,7 +183,7 @@ class Block<T> {
   final BlockType type;
 
   /// The current error for this block, if any.
-  CorbadoError? error;
+  CorbadoAuthException? error;
 
   /// The data backing this block.
   T data;
@@ -184,7 +204,7 @@ class Block<T> {
     try {
       final res = await corbadoService.resetAuthProcess();
       processHandler.updateBlockFromServer(res);
-    } on CorbadoError catch (e) {
+    } on CorbadoAuthException catch (e) {
       processHandler.updateBlockFromError(e);
     }
   }

--- a/packages/corbado_auth/lib/src/corbado_auth_component.dart
+++ b/packages/corbado_auth/lib/src/corbado_auth_component.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: library_private_types_in_public_api
-
 import 'package:corbado_auth/corbado_auth.dart';
 import 'package:corbado_auth/src/process_handler.dart';
 import 'package:flutter/material.dart';
@@ -59,7 +57,7 @@ class CorbadoAuthComponent extends StatefulWidget {
   final Widget? loading;
 
   @override
-  _CorbadoAuthComponentState createState() => _CorbadoAuthComponentState();
+  State<CorbadoAuthComponent> createState() => _CorbadoAuthComponentState();
 }
 
 class _CorbadoAuthComponentState extends State<CorbadoAuthComponent> {

--- a/packages/corbado_auth/lib/src/process_handler.dart
+++ b/packages/corbado_auth/lib/src/process_handler.dart
@@ -69,7 +69,7 @@ class ProcessHandler {
   }
 
   /// Attaches the given [error] to the current block and re-emits it.
-  void updateBlockFromError(CorbadoError error) {
+  void updateBlockFromError(CorbadoAuthException error) {
     if (_currentBlock == null) {
       return;
     }
@@ -101,7 +101,7 @@ class ProcessHandler {
           processHandler: this,
           data: SignupInitBlockData.fromProcessResponse(typed),
         );
-        block.error = CorbadoError.fromRequestError(typed.error);
+        block.error = CorbadoAuthException.fromRequestError(typed.error);
 
       case BlockType.loginInit:
         final typed = body.data.oneOf.value! as GeneralBlockLoginInit;
@@ -109,7 +109,7 @@ class ProcessHandler {
           processHandler: this,
           data: LoginInitBlockData.fromProcessResponse(typed),
         );
-        block.error = CorbadoError.fromRequestError(typed.error);
+        block.error = CorbadoAuthException.fromRequestError(typed.error);
 
       case BlockType.emailVerify:
         final typed = body.data.oneOf.value! as GeneralBlockVerifyIdentifier;
@@ -118,7 +118,7 @@ class ProcessHandler {
           data: EmailVerifyBlockData.fromProcessResponse(typed),
           authType: body.authType,
         );
-        block.error = CorbadoError.fromRequestError(typed.error);
+        block.error = CorbadoAuthException.fromRequestError(typed.error);
 
       case BlockType.completed:
         final typed = body.data.oneOf.value! as GeneralBlockCompleted;
@@ -147,7 +147,7 @@ class ProcessHandler {
     }
 
     if (body.error != null) {
-      block.error = CorbadoError(
+      block.error = CorbadoAuthException(
         errorCode: body.error!.code,
         translatedError: Translator.error(body.error!.code),
       );

--- a/packages/corbado_auth/lib/src/services/corbado/corbado.dart
+++ b/packages/corbado_auth/lib/src/services/corbado/corbado.dart
@@ -2,10 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:built_collection/built_collection.dart';
-import 'package:corbado_auth/corbado_auth.dart';
+import 'package:corbado_auth/corbado_auth.dart' hide VerificationMethod;
 import 'package:corbado_auth/src/services/storage/storage.dart';
-import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart'
-    as api;
 import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
@@ -25,7 +23,7 @@ abstract class CorbadoService {
   );
 
   /// The client used to communicate with the Corbado frontend API.
-  final api.CorbadoFrontendApiClient frontendAPIClient;
+  final CorbadoFrontendApiClient frontendAPIClient;
 
   /// The authenticator used to create and verify passkeys.
   final PasskeyAuthenticator passkeyAuthenticator;
@@ -36,9 +34,9 @@ abstract class CorbadoService {
       passkeyAuthenticator.resultStream.distinct();
 
   /// Initializes a new authentication process.
-  Future<api.ProcessResponse> initAuthProcess() async {
+  Future<ProcessResponse> initAuthProcess() async {
     final ciBuilder = await _buildClientInformation();
-    final processInitReq = api.ProcessInitReq(
+    final processInitReq = ProcessInitReq(
       (b) => b..clientInformation = ciBuilder,
     );
     final res = await frontendAPIClient.getAuthApi().processInit(
@@ -58,14 +56,14 @@ abstract class CorbadoService {
   }
 
   /// Completes the current authentication process.
-  Future<api.ProcessResponse> completeAuthProcess() async {
+  Future<ProcessResponse> completeAuthProcess() async {
     return _wrapWithError(
       () => frontendAPIClient.getAuthApi().processComplete(),
     );
   }
 
   /// Resets the current authentication process, optionally starting a new one.
-  Future<api.ProcessResponse> resetAuthProcess() async {
+  Future<ProcessResponse> resetAuthProcess() async {
     final out = await _wrapWithError(
       () => frontendAPIClient.getAuthApi().processReset(),
     );
@@ -82,22 +80,22 @@ abstract class CorbadoService {
   void clearAuthProcess() {}
 
   /// Starts a signup process for the given [email] and/or [fullName].
-  Future<api.ProcessResponse> signupInit({
+  Future<ProcessResponse> signupInit({
     String? email,
     String? fullName,
   }) async {
-    final identifierBuilder = ListBuilder<api.LoginIdentifier>();
+    final identifierBuilder = ListBuilder<LoginIdentifier>();
     if (email != null) {
       identifierBuilder.add(
-        api.LoginIdentifier(
+        LoginIdentifier(
           (b) => b
-            ..type = api.LoginIdentifierType.email
+            ..type = LoginIdentifierType.email
             ..identifier = email,
         ),
       );
     }
 
-    final signupInitReq = api.SignupInitReq(
+    final signupInitReq = SignupInitReq(
       (b) => b
         ..fullName = fullName
         ..identifiers = identifierBuilder,
@@ -111,11 +109,11 @@ abstract class CorbadoService {
   }
 
   /// Starts a login process for the given [loginIdentifier].
-  Future<api.ProcessResponse> loginInit(
+  Future<ProcessResponse> loginInit(
     String loginIdentifier,
     bool isPhone,
   ) async {
-    final req = api.LoginInitReq(
+    final req = LoginInitReq(
       (b) => b
         ..identifierValue = loginIdentifier
         ..isPhone = isPhone,
@@ -127,10 +125,10 @@ abstract class CorbadoService {
   }
 
   /// Finishes a passkey mediation with the given [signedChallenge].
-  Future<api.ProcessResponse> finishPasskeyMediation(
+  Future<ProcessResponse> finishPasskeyMediation(
     String signedChallenge,
   ) async {
-    final req = api.PasskeyMediationFinishReq(
+    final req = PasskeyMediationFinishReq(
       (b) => b..signedChallenge = signedChallenge,
     );
 
@@ -142,12 +140,12 @@ abstract class CorbadoService {
   }
 
   /// Verifies the email one-time passcode [code].
-  Future<api.ProcessResponse> verifyEmailOtpCode(String code) async {
-    final req = api.IdentifierVerifyFinishReq(
+  Future<ProcessResponse> verifyEmailOtpCode(String code) async {
+    final req = IdentifierVerifyFinishReq(
       (b) => b
         ..code = code
-        ..identifierType = api.LoginIdentifierType.email
-        ..verificationType = api.VerificationMethod.emailOtp
+        ..identifierType = LoginIdentifierType.email
+        ..verificationType = VerificationMethod.emailOtp
         ..isNewDevice = false,
     );
 
@@ -159,11 +157,11 @@ abstract class CorbadoService {
   }
 
   /// Sends an email one-time passcode to the current identifier.
-  Future<api.ProcessResponse> sendEmailOtpCode() async {
-    final req = api.IdentifierVerifyStartReq(
+  Future<ProcessResponse> sendEmailOtpCode() async {
+    final req = IdentifierVerifyStartReq(
       (b) => b
-        ..identifierType = api.LoginIdentifierType.email
-        ..verificationType = api.VerificationMethod.emailOtp,
+        ..identifierType = LoginIdentifierType.email
+        ..verificationType = VerificationMethod.emailOtp,
     );
 
     return _wrapWithError(
@@ -174,11 +172,11 @@ abstract class CorbadoService {
   }
 
   /// Sends an email magic link to the current identifier.
-  Future<api.ProcessResponse> sendEmailLink() async {
-    final req = api.IdentifierVerifyStartReq(
+  Future<ProcessResponse> sendEmailLink() async {
+    final req = IdentifierVerifyStartReq(
       (b) => b
-        ..identifierType = api.LoginIdentifierType.email
-        ..verificationType = api.VerificationMethod.emailLink,
+        ..identifierType = LoginIdentifierType.email
+        ..verificationType = VerificationMethod.emailLink,
     );
 
     return _wrapWithError(
@@ -189,10 +187,10 @@ abstract class CorbadoService {
   }
 
   /// Updates the email identifier to [email].
-  Future<api.ProcessResponse> updateEmail(String email) async {
-    final req = api.IdentifierUpdateReq(
+  Future<ProcessResponse> updateEmail(String email) async {
+    final req = IdentifierUpdateReq(
       (b) => b
-        ..identifierType = api.LoginIdentifierType.email
+        ..identifierType = LoginIdentifierType.email
         ..value = email,
     );
 
@@ -204,7 +202,7 @@ abstract class CorbadoService {
   }
 
   /// passkey related functionalities
-  Future<api.ProcessResponse> appendPasskey() async {
+  Future<ProcessResponse> appendPasskey() async {
     final startRes = await _wrapWithError(
       () => frontendAPIClient.getAuthApi().passkeyAppendStart(
         passkeyAppendStartReq: PasskeyAppendStartReq(),
@@ -215,7 +213,7 @@ abstract class CorbadoService {
     }
 
     final body =
-        startRes.blockBody.data.oneOf.value! as api.GeneralBlockPasskeyAppend;
+        startRes.blockBody.data.oneOf.value! as GeneralBlockPasskeyAppend;
     final json = jsonDecode(body.challenge) as Map<String, dynamic>;
 
     final authenticatorReq = StartRegisterResponse.fromJson(
@@ -231,7 +229,7 @@ abstract class CorbadoService {
           authenticatorRes,
         ).toJson(),
       );
-      final passkeyAppendReq = api.PasskeyAppendFinishReq(
+      final passkeyAppendReq = PasskeyAppendFinishReq(
         (b) => b..signedChallenge = attestationResponse,
       );
 
@@ -248,7 +246,7 @@ abstract class CorbadoService {
   /// Appends a passkey to the currently signed in user.
   Future<void> sessionAppendPasskey() async {
     final ci = await _buildClientInformation();
-    final startReq = api.MePasskeysAppendStartReq(
+    final startReq = MePasskeysAppendStartReq(
       (b) => b..clientInformation = ci,
     );
     final startRes = await _wrapWithError(
@@ -275,7 +273,7 @@ abstract class CorbadoService {
           authenticatorRes,
         ).toJson(),
       );
-      final mePasskeysAppendFinishReq = api.MePasskeysAppendFinishReq(
+      final mePasskeysAppendFinishReq = MePasskeysAppendFinishReq(
         (b) => b
           ..attestationResponse = attestationResponse
           ..clientInformation = ci,
@@ -294,7 +292,7 @@ abstract class CorbadoService {
   }
 
   /// Lists the passkeys of the currently signed in user.
-  Future<List<api.Passkey>> sessionListPasskeys({String? token}) async {
+  Future<List<Passkey>> sessionListPasskeys({String? token}) async {
     final res = await _wrapWithError(
       () => frontendAPIClient.getUsersApi().currentUserPasskeyGet(),
     );
@@ -313,7 +311,7 @@ abstract class CorbadoService {
 
   /// Updates the currently signed in user, e.g. their [fullname].
   Future<void> sessionUpdateUser({String? fullname}) async {
-    final meUpdateReq = api.MeUpdateReq((b) => b..fullName = fullname);
+    final meUpdateReq = MeUpdateReq((b) => b..fullName = fullname);
     await _wrapWithErrorEmptyResponse(
       () => frontendAPIClient.getUsersApi().currentUserUpdate(
         meUpdateReq: meUpdateReq,
@@ -322,10 +320,10 @@ abstract class CorbadoService {
   }
 
   /// Verifies the user by triggering a passkey login.
-  Future<api.ProcessResponse> verifyPasskey() async {
+  Future<ProcessResponse> verifyPasskey() async {
     final startRes = await _wrapWithError(
       () => frontendAPIClient.getAuthApi().passkeyLoginStart(
-        passkeyLoginStartReq: api.PasskeyLoginStartReq(),
+        passkeyLoginStartReq: PasskeyLoginStartReq(),
       ),
     );
     if (startRes.blockBody.error != null) {
@@ -333,7 +331,7 @@ abstract class CorbadoService {
     }
 
     final body =
-        startRes.blockBody.data.oneOf.value! as api.GeneralBlockPasskeyVerify;
+        startRes.blockBody.data.oneOf.value! as GeneralBlockPasskeyVerify;
     final json = jsonDecode(body.challenge) as Map<String, dynamic>;
 
     final authenticatorReq = StartLoginResponse.fromJson(json).toPlatformType(
@@ -347,7 +345,7 @@ abstract class CorbadoService {
       final assertionResponse = jsonEncode(
         FinishLoginRequest.fromPlatformType(authenticatorRes).toJson(),
       );
-      final passkeyLoginFinishReq = api.PasskeyLoginFinishReq(
+      final passkeyLoginFinishReq = PasskeyLoginFinishReq(
         (b) => b..signedChallenge = assertionResponse,
       );
 
@@ -366,7 +364,7 @@ abstract class CorbadoService {
   }
 
   /// Verifies the user with a conditional (mediated) passkey [challenge].
-  Future<api.ProcessResponse> verifyPasskeyConditional(
+  Future<ProcessResponse> verifyPasskeyConditional(
     String challenge,
     bool silent,
   ) async {
@@ -382,7 +380,7 @@ abstract class CorbadoService {
       final assertionResponse = jsonEncode(
         FinishLoginRequest.fromPlatformType(authenticatorRes).toJson(),
       );
-      final passkeyLoginFinishReq = api.PasskeyMediationFinishReq(
+      final passkeyLoginFinishReq = PasskeyMediationFinishReq(
         (b) => b..signedChallenge = assertionResponse,
       );
 
@@ -439,13 +437,13 @@ abstract class CorbadoService {
     return;
   }
 
-  Future<api.ClientInformationBuilder> _buildClientInformation() async {
+  Future<ClientInformationBuilder> _buildClientInformation() async {
     final clientEnvHandle = await _storageService.getClientEnvHandle();
     final getAvailability = passkeyAuthenticator.getAvailability();
 
     if (kIsWeb) {
       final passkeyAvailability = await getAvailability.web();
-      return api.ClientInformationBuilder()
+      return ClientInformationBuilder()
         ..isNative = passkeyAvailability.isNative
         ..isUserVerifyingPlatformAuthenticatorAvailable =
             passkeyAvailability.isUserVerifyingPlatformAuthenticatorAvailable
@@ -454,7 +452,7 @@ abstract class CorbadoService {
         ..clientEnvHandle = clientEnvHandle;
     } else if (Platform.isIOS) {
       final passkeyAvailability = await getAvailability.iOS();
-      return api.ClientInformationBuilder()
+      return ClientInformationBuilder()
         ..isNative = passkeyAvailability.isNative
         ..isUserVerifyingPlatformAuthenticatorAvailable =
             passkeyAvailability.hasBiometrics
@@ -462,7 +460,7 @@ abstract class CorbadoService {
         ..clientEnvHandle = clientEnvHandle;
     } else {
       final passkeyAvailability = await getAvailability.android();
-      return api.ClientInformationBuilder()
+      return ClientInformationBuilder()
         ..isNative = passkeyAvailability.isNative
         ..isUserVerifyingPlatformAuthenticatorAvailable =
             passkeyAvailability.isUserVerifyingPlatformAuthenticatorAvailable

--- a/packages/corbado_auth/lib/src/services/corbado/corbado.dart
+++ b/packages/corbado_auth/lib/src/services/corbado/corbado.dart
@@ -12,7 +12,7 @@ import 'package:flutter/foundation.dart';
 import 'package:passkeys/authenticator.dart';
 import 'package:passkeys/types.dart';
 
-// ignore_for_file: avoid_positional_boolean_parameters, only_throw_errors
+// ignore_for_file: avoid_positional_boolean_parameters
 
 /// Talks to the Corbado frontend API to drive authentication processes.
 abstract class CorbadoService {
@@ -45,7 +45,7 @@ abstract class CorbadoService {
       processInitReq: processInitReq,
     );
     if (res.data == null) {
-      throw CorbadoError.fromMissingServerResponse();
+      throw CorbadoAuthException.fromMissingServerResponse();
     }
 
     if (res.data!.newClientEnvHandle != null) {
@@ -211,7 +211,7 @@ abstract class CorbadoService {
       ),
     );
     if (startRes.blockBody.error != null) {
-      throw CorbadoError.fromMissingServerResponse();
+      throw CorbadoAuthException.fromMissingServerResponse();
     }
 
     final body =
@@ -241,7 +241,7 @@ abstract class CorbadoService {
         ),
       );
     } on AuthenticatorException catch (e) {
-      throw CorbadoError.fromAuthenticatorError(e);
+      throw CorbadoAuthException.fromAuthenticatorError(e);
     }
   }
 
@@ -258,7 +258,7 @@ abstract class CorbadoService {
     );
 
     if (startRes.attestationOptions.isEmpty) {
-      throw CorbadoError.fromMissingServerResponse();
+      throw CorbadoAuthException.fromMissingServerResponse();
     }
 
     final json =
@@ -287,9 +287,9 @@ abstract class CorbadoService {
         ),
       );
     } on AuthenticatorException catch (e) {
-      throw CorbadoError.fromAuthenticatorError(e);
+      throw CorbadoAuthException.fromAuthenticatorError(e);
     } catch (e) {
-      throw CorbadoError.fromUnknownError(e);
+      throw CorbadoAuthException.fromUnknownError(e);
     }
   }
 
@@ -329,7 +329,7 @@ abstract class CorbadoService {
       ),
     );
     if (startRes.blockBody.error != null) {
-      throw CorbadoError.fromMissingServerResponse();
+      throw CorbadoAuthException.fromMissingServerResponse();
     }
 
     final body =
@@ -361,7 +361,7 @@ abstract class CorbadoService {
         rethrow;
       }
 
-      throw CorbadoError.fromAuthenticatorError(e);
+      throw CorbadoAuthException.fromAuthenticatorError(e);
     }
   }
 
@@ -397,7 +397,7 @@ abstract class CorbadoService {
         rethrow;
       }
 
-      throw CorbadoError.fromAuthenticatorError(e);
+      throw CorbadoAuthException.fromAuthenticatorError(e);
     }
   }
 
@@ -411,11 +411,11 @@ abstract class CorbadoService {
     try {
       response = await callback();
     } catch (e) {
-      throw CorbadoError.fromUnknownError(e);
+      throw CorbadoAuthException.fromUnknownError(e);
     }
 
     if (response.data == null) {
-      throw CorbadoError.fromMissingServerResponse();
+      throw CorbadoAuthException.fromMissingServerResponse();
     }
 
     return response.data!;
@@ -427,7 +427,7 @@ abstract class CorbadoService {
     try {
       await callback();
     } catch (e) {
-      throw CorbadoError.fromUnknownError(e);
+      throw CorbadoAuthException.fromUnknownError(e);
     }
   }
 

--- a/packages/corbado_auth/lib/src/services/session/session.dart
+++ b/packages/corbado_auth/lib/src/services/session/session.dart
@@ -5,8 +5,6 @@ import 'package:corbado_auth/src/services/storage/storage.dart';
 import 'package:corbado_frontend_api_client/corbado_frontend_api_client.dart';
 import 'package:flutter/foundation.dart';
 
-// ignore_for_file: only_throw_errors
-
 /// Manages the user session, including token refresh and auth state streams.
 class SessionService {
   /// Creates a [SessionService] backed by the given storage service and
@@ -180,7 +178,7 @@ class SessionService {
         .getUsersApi()
         .currentUserSessionRefresh();
     if (response.data == null) {
-      throw CorbadoError.fromMissingServerResponse();
+      throw CorbadoAuthException.fromMissingServerResponse();
     }
 
     final user = User.fromIdToken(response.data!.shortSession);

--- a/packages/corbado_auth/lib/src/types/exceptions/exceptions.dart
+++ b/packages/corbado_auth/lib/src/types/exceptions/exceptions.dart
@@ -6,7 +6,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'exceptions.g.dart';
 
 /// Base class for all exceptions thrown by the Corbado Auth SDK.
-class CorbadoException implements Exception {
+sealed class CorbadoException implements Exception {
   /// Constructor
   CorbadoException(this._message);
 

--- a/packages/corbado_auth_firebase/lib/src/services/corbado.dart
+++ b/packages/corbado_auth_firebase/lib/src/services/corbado.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: prefer_constructors_over_static_methods
-
 import 'dart:convert';
 
 import 'package:cloud_functions/cloud_functions.dart';
@@ -11,6 +9,13 @@ import 'package:passkeys/types.dart';
 class CorbadoService {
   /// Creates a [CorbadoService] backed by the given [functions] instance.
   CorbadoService(FirebaseFunctions functions) : _functions = functions;
+
+  /// Returns a lazily created singleton backed by the default Firebase
+  /// Functions instance.
+  factory CorbadoService.getInstance() {
+    return _instance ??= CorbadoService(FirebaseFunctions.instance);
+  }
+
   final FirebaseFunctions _functions;
   static final _functionOptions = HttpsCallableOptions(
     timeout: const Duration(seconds: 10),
@@ -19,13 +24,6 @@ class CorbadoService {
   String? _ongoingEmailOTPCodeID;
 
   static CorbadoService? _instance;
-
-  /// Returns a lazily created singleton backed by the default Firebase
-  /// Functions instance.
-  static CorbadoService getInstance() {
-    _instance ??= CorbadoService(FirebaseFunctions.instance);
-    return _instance!;
-  }
 
   /// Starts a passkey sign up and returns the registration challenge.
   Future<RegisterRequestType> startSignUpWithPasskey(

--- a/packages/passkeys/passkeys/example/lib/error_handling.dart
+++ b/packages/passkeys/passkeys/example/lib/error_handling.dart
@@ -4,40 +4,39 @@ import 'package:passkeys/exceptions.dart';
 
 /// Returns a user-friendly error message for the given
 /// [AuthenticatorException].
+///
+/// The switch is exhaustive over the sealed [AuthenticatorException]
+/// hierarchy, so adding a new exception type fails to compile until it is
+/// handled here.
 String getFriendlyErrorMessage(AuthenticatorException exception) {
-  if (exception is PasskeyAuthCancelledException) {
-    return 'Authentication was cancelled. Please try again.';
-  } else if (exception is MissingGoogleSignInException) {
-    return 'You need to be signed into your Google account to use passkeys.';
-  } else if (exception is SyncAccountNotAvailableException) {
-    return 'Your sync account is not available. Please sign in and try again.';
-  } else if (exception is ExcludeCredentialsCanNotBeRegisteredException) {
-    return 'Some credentials cannot be registered. '
-        'Please check and try again.';
-  } else if (exception is NoCredentialsAvailableException) {
-    return 'No credentials available. '
-        'Try another login method, such as email OTP.';
-  } else if (exception is DomainNotAssociatedException) {
-    return exception.message ??
-        'This domain is not correctly associated. '
-            'Please check your configuration.';
-  } else if (exception is DeviceNotSupportedException) {
-    return 'This device does not support passkeys. Please update your OS.';
-  } else if (exception is NoCreateOptionException) {
-    return exception.message ??
-        'No viable options found to create a credential. '
-            'Check device settings.';
-  } else if (exception is TimeoutException) {
-    return exception.message ?? 'The operation timed out. Please try again.';
-  } else if (exception is MalformedBase64Url) {
-    return exception.toString();
-  } else if (exception is UnhandledAuthenticatorException) {
-    return 'An unexpected error occurred (Code: ${exception.code}). '
-        'Please contact support.';
-  } else if (exception is PasskeyUnsupportedException) {
-    return 'This device does not support passkeys '
-        '(requires at least Android SDK 28). Please update your OS.';
-  } else {
-    return 'An unknown error occurred. Please try again later.';
-  }
+  return switch (exception) {
+    PasskeyAuthCancelledException() =>
+      'Authentication was cancelled. Please try again.',
+    MissingGoogleSignInException() =>
+      'You need to be signed into your Google account to use passkeys.',
+    SyncAccountNotAvailableException() =>
+      'Your sync account is not available. Please sign in and try again.',
+    ExcludeCredentialsCanNotBeRegisteredException() =>
+      'Some credentials cannot be registered. Please check and try again.',
+    NoCredentialsAvailableException() =>
+      'No credentials available. Try another login method, such as email OTP.',
+    DomainNotAssociatedException(:final message) =>
+      message ??
+          'This domain is not correctly associated. '
+              'Please check your configuration.',
+    DeviceNotSupportedException() =>
+      'This device does not support passkeys. Please update your OS.',
+    NoCreateOptionException(:final message) =>
+      message ??
+          'No viable options found to create a credential. '
+              'Check device settings.',
+    TimeoutException(:final message) =>
+      message ?? 'The operation timed out. Please try again.',
+    MalformedBase64Url() => exception.toString(),
+    UnhandledAuthenticatorException(:final code) =>
+      'An unexpected error occurred (Code: $code). Please contact support.',
+    PasskeyUnsupportedException() =>
+      'This device does not support passkeys '
+          '(requires at least Android SDK 28). Please update your OS.',
+  };
 }

--- a/packages/passkeys/passkeys/example/lib/widgets/select_test_configuration.dart
+++ b/packages/passkeys/passkeys/example/lib/widgets/select_test_configuration.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: library_private_types_in_public_api
-
 import 'package:flutter/material.dart';
 import 'package:passkeys_example/auth_service.dart';
 
@@ -16,7 +14,7 @@ class SelectTestConfiguration extends StatefulWidget {
   final List<Configuration> configurations;
 
   @override
-  _SelectTestConfigurationState createState() =>
+  State<SelectTestConfiguration> createState() =>
       _SelectTestConfigurationState();
 }
 

--- a/packages/passkeys/passkeys/lib/exceptions.dart
+++ b/packages/passkeys/passkeys/lib/exceptions.dart
@@ -1,6 +1,6 @@
 /// Used as a base exception for all authenticator exceptions thrown by this
 /// package.
-class AuthenticatorException implements Exception {}
+sealed class AuthenticatorException implements Exception {}
 
 /// Thrown when the user cancels the passkey flow.
 ///
@@ -127,7 +127,7 @@ class TimeoutException implements AuthenticatorException {
 
 /// This exception is thrown when a string is not a valid Base64URL encoded
 /// string.
-abstract class MalformedBase64Url implements AuthenticatorException {
+sealed class MalformedBase64Url implements AuthenticatorException {
   @override
   String toString();
 }

--- a/packages/passkeys/passkeys_web/lib/models/passkey_login_request.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkey_login_request.dart
@@ -1,10 +1,10 @@
-// ignore_for_file: file_names, constant_identifier_names
+// ignore_for_file: constant_identifier_names
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:passkeys_platform_interface/types/credential.dart';
 import 'package:passkeys_platform_interface/types/types.dart';
 
-part 'passkeyLoginRequest.g.dart';
+part 'passkey_login_request.g.dart';
 
 /// Request payload sent to the Web SDK to authenticate with a passkey.
 @JsonSerializable(explicitToJson: true)

--- a/packages/passkeys/passkeys_web/lib/models/passkey_login_request.g.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkey_login_request.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'passkeyLoginRequest.dart';
+part of 'passkey_login_request.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator

--- a/packages/passkeys/passkeys_web/lib/models/passkey_login_response.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkey_login_response.dart
@@ -1,9 +1,7 @@
-// ignore_for_file: file_names
-
 import 'package:json_annotation/json_annotation.dart';
 import 'package:passkeys_platform_interface/types/types.dart';
 
-part 'passkeyLoginResponse.g.dart';
+part 'passkey_login_response.g.dart';
 
 /// Response returned by the Web SDK after a successful passkey login.
 @JsonSerializable()

--- a/packages/passkeys/passkeys_web/lib/models/passkey_login_response.g.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkey_login_response.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'passkeyLoginResponse.dart';
+part of 'passkey_login_response.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator

--- a/packages/passkeys/passkeys_web/lib/models/passkey_sign_up_request.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkey_sign_up_request.dart
@@ -1,11 +1,9 @@
-// ignore_for_file: file_names
-
 import 'package:json_annotation/json_annotation.dart';
 import 'package:passkeys_platform_interface/types/credential.dart';
 import 'package:passkeys_platform_interface/types/pubkeycred_param.dart';
 import 'package:passkeys_platform_interface/types/types.dart';
 
-part 'passkeySignUpRequest.g.dart';
+part 'passkey_sign_up_request.g.dart';
 
 /// Request payload sent to the Web SDK to register a new passkey.
 @JsonSerializable(createFactory: false, explicitToJson: true)

--- a/packages/passkeys/passkeys_web/lib/models/passkey_sign_up_request.g.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkey_sign_up_request.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'passkeySignUpRequest.dart';
+part of 'passkey_sign_up_request.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator

--- a/packages/passkeys/passkeys_web/lib/models/passkey_sign_up_response.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkey_sign_up_response.dart
@@ -1,8 +1,6 @@
-// ignore_for_file: file_names
-
 import 'package:json_annotation/json_annotation.dart';
 
-part 'passkeySignUpResponse.g.dart';
+part 'passkey_sign_up_response.g.dart';
 
 /// Response returned by the Web SDK after a successful passkey registration.
 @JsonSerializable()

--- a/packages/passkeys/passkeys_web/lib/models/passkey_sign_up_response.g.dart
+++ b/packages/passkeys/passkeys_web/lib/models/passkey_sign_up_response.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'passkeySignUpResponse.dart';
+part of 'passkey_sign_up_response.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator

--- a/packages/passkeys/passkeys_web/lib/passkeys_web.dart
+++ b/packages/passkeys/passkeys_web/lib/passkeys_web.dart
@@ -6,10 +6,10 @@ import 'package:flutter/services.dart';
 import 'package:passkeys_platform_interface/passkeys_platform_interface.dart';
 import 'package:passkeys_platform_interface/types/types.dart';
 import 'package:passkeys_web/interop.dart';
-import 'package:passkeys_web/models/passkeyLoginRequest.dart';
-import 'package:passkeys_web/models/passkeyLoginResponse.dart';
-import 'package:passkeys_web/models/passkeySignUpRequest.dart';
-import 'package:passkeys_web/models/passkeySignUpResponse.dart';
+import 'package:passkeys_web/models/passkey_login_request.dart';
+import 'package:passkeys_web/models/passkey_login_response.dart';
+import 'package:passkeys_web/models/passkey_sign_up_request.dart';
+import 'package:passkeys_web/models/passkey_sign_up_response.dart';
 import 'package:web/web.dart';
 
 /// The Web implementation of [PasskeysPlatform].


### PR DESCRIPTION
## Summary

Resolves fixable analyzer lint ignores across the workspace and refines the exception design. No runtime behaviour changes.

### Lint cleanup
- Dropped `// ignore` directives that can be satisfied directly:
  - `createState()` return type → `State<T>` (`corbado_auth`, example widget)
  - `getInstance` / `fromAuthenticatorError` static methods → factory constructors
  - `as Api` import prefix → `as api`
  - removed a stale `invalid_use_of_protected_member` token that no longer fired
- Renamed `passkeys_web/lib/models/passkey*.dart` to snake_case (`file_names`), updating imports and `part` directives.

### Exception types
- Added `CorbadoAuthException extends CorbadoError`; internal code now throws/catches `CorbadoAuthException`. `CorbadoError` is deprecated but retained as the base, so existing `on CorbadoError` catch clauses keep working unchanged.
- Made the message-based `CorbadoException` hierarchy and the `AuthenticatorException` hierarchy `sealed`.
- Rewrote the example `getFriendlyErrorMessage` as an exhaustive `switch` over the sealed `AuthenticatorException`.

### Intentionally left as-is
Ignores that reflect deliberate decisions were kept: pigeon positional bools (drive generated native signatures), PascalCase enum values with `@JsonValue` wire mappings, deprecated-parameter forwarding for backward compatibility, tear-off setter methods in the example, and `@protected` member access in `ProcessHandler`.

## Verification
- `melos format --set-exit-if-changed` ✅
- `melos analyze` (`dart analyze --fatal-infos`) ✅
- `melos test` ✅