### PR TITLE
feat(passkeys_doctor): add web/macOS/Windows checks and only run doctor in debug mode

### DIFF
--- a/packages/passkeys/passkeys/lib/authenticator.dart
+++ b/packages/passkeys/passkeys/lib/authenticator.dart
@@ -11,10 +11,15 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
   /// Constructor
   PasskeyAuthenticator({bool? debugMode})
     : _platform = PasskeysPlatform.instance,
-      debugMode = debugMode ?? false;
+      debugMode = debugMode ?? false {
+    if (this.debugMode) {
+      _doctor = PasskeysDoctor();
+    }
+  }
 
-  /// The [PasskeysDoctor] instance for debugging and checking passkeys
-  final _doctor = PasskeysDoctor();
+  /// The [PasskeysDoctor] instance for debugging and checking passkeys.
+  /// Only created when [debugMode] is enabled.
+  PasskeysDoctor? _doctor;
 
   /// The platform interface for passkeys.
   final PasskeysPlatform _platform;
@@ -37,7 +42,9 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
   }
 
   /// Returns a stream of results from the debugging doctor.
-  Stream<Result> get resultStream => _doctor.resultStream;
+  /// Emits nothing when [debugMode] is disabled.
+  Stream<Result> get resultStream =>
+      _doctor?.resultStream ?? const Stream<Result>.empty();
 
   /// Creates a new passkey and stores it on the device.
   /// Returns [RegisterResponseType] which must be sent to the relying party
@@ -45,7 +52,7 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
   @override
   Future<RegisterResponseType> register(RegisterRequestType request) async {
     if (debugMode) {
-      await _doctor.check(request.relyingParty.id);
+      await _doctor?.check(request.relyingParty.id);
     }
 
     try {
@@ -64,7 +71,7 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
       return r;
     } on PlatformException catch (e) {
       if (debugMode) {
-        _doctor.recordException(e);
+        _doctor?.recordException(e);
       }
 
       switch (e.code) {
@@ -108,7 +115,7 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
     AuthenticateRequestType request,
   ) async {
     if (debugMode) {
-      await _doctor.check(request.relyingPartyId);
+      await _doctor?.check(request.relyingPartyId);
     }
 
     try {
@@ -127,7 +134,7 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
       return r;
     } on PlatformException catch (e) {
       if (debugMode) {
-        _doctor.recordException(e);
+        _doctor?.recordException(e);
       }
 
       switch (e.code) {
@@ -217,7 +224,7 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
 
   Never _mapSignalException(PlatformException e, StackTrace stackTrace) {
     if (debugMode) {
-      _doctor.recordException(e);
+      _doctor?.recordException(e);
     }
 
     switch (e.code) {
@@ -261,7 +268,7 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
   void _isValidChallenge(String challenge) {
     if (!_isValidBase64Url(input: challenge)) {
       if (debugMode) {
-        _doctor.recordException(
+        _doctor?.recordException(
           PlatformException(code: 'malformed-base64-url-challenge'),
         );
       }
@@ -273,7 +280,7 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
   void _isValidCredentialID(String credentialID) {
     if (!_isValidBase64Url(input: credentialID)) {
       if (debugMode) {
-        _doctor.recordException(
+        _doctor?.recordException(
           PlatformException(code: 'malformed-base64-url-credential-id'),
         );
       }
@@ -285,7 +292,7 @@ class PasskeyAuthenticator implements PasskeyAuthenticatorInterface {
   void _isValidUserID(String userID) {
     if (!_isValidBase64Url(input: userID, allowPadding: true)) {
       if (debugMode) {
-        _doctor.recordException(
+        _doctor?.recordException(
           PlatformException(code: 'malformed-base64-url-user-id'),
         );
       }

--- a/packages/passkeys/passkeys_doctor/lib/src/checks.dart
+++ b/packages/passkeys/passkeys_doctor/lib/src/checks.dart
@@ -1,0 +1,199 @@
+import 'types/checkpoint.dart';
+import 'types/exceptions.dart';
+
+/// Documentation links surfaced on failing checkpoints.
+class DocLinks {
+  static const flutterIntegration =
+      'https://docs.corbado.com/corbado-complete/frontend-integration/flutter';
+  static const ios =
+      'https://docs.corbado.com/corbado-complete/frontend-integration/flutter/run-on-physical-device/ios/overview';
+  static const android =
+      'https://docs.corbado.com/corbado-complete/frontend-integration/flutter/run-on-physical-device/android/overview';
+}
+
+/// Validates the RPID value.
+///
+/// When [hostname] is non-null the check runs in a web context and also
+/// verifies that the RPID is valid for the current hostname. Throws a
+/// [DoctorException] for blocking format errors so later checks are skipped.
+Checkpoint checkRpidValue(String rpid, {String? hostname}) {
+  if (rpid.isEmpty) {
+    throw DoctorException(
+      blockingCheckpoint: Checkpoint(
+        name: 'RPID check',
+        description: 'RPID is not set',
+        type: CheckpointType.error,
+        documentationLink: DocLinks.flutterIntegration,
+      ),
+    );
+  }
+
+  if (rpid.contains('://') || rpid.contains('/')) {
+    String? host;
+    try {
+      final parsed = Uri.parse(rpid).host.toLowerCase();
+      if (parsed.isNotEmpty) {
+        host = parsed;
+      }
+    } catch (_) {
+      host = null;
+    }
+
+    throw DoctorException(
+      blockingCheckpoint: Checkpoint(
+        name: 'RPID check',
+        description: host != null
+            ? 'RPID must be just a hostname, not a URL. Did you mean "$host"?'
+            : 'RPID "$rpid" is not a valid URL or hostname.',
+        type: CheckpointType.error,
+        documentationLink: DocLinks.flutterIntegration,
+      ),
+    );
+  }
+
+  if (hostname != null) {
+    final normalizedHost = hostname.toLowerCase();
+    final matches = normalizedHost == rpid || normalizedHost.endsWith('.$rpid');
+
+    if (!matches) {
+      return Checkpoint(
+        name: 'RPID check',
+        description:
+            'RPID "$rpid" is NOT valid for hostname "$normalizedHost".',
+        type: CheckpointType.error,
+        documentationLink: DocLinks.flutterIntegration,
+      );
+    }
+
+    return Checkpoint(
+      name: 'RPID check',
+      description: 'RPID "$rpid" is valid for hostname "$normalizedHost".',
+      type: CheckpointType.success,
+    );
+  }
+
+  return Checkpoint(
+    name: 'RPID check',
+    description: 'RPID is set correctly ("$rpid").',
+    type: CheckpointType.success,
+  );
+}
+
+/// Evaluates a parsed AASA JSON body for the given [bundleId].
+Checkpoint evaluateAasa(
+  Uri uri,
+  Map<String, dynamic> jsonBody,
+  String bundleId,
+) {
+  bool matchesBundle(String fullId) {
+    final dotIndex = fullId.indexOf('.');
+    if (dotIndex <= 0 || dotIndex >= fullId.length - 1) {
+      return false;
+    }
+    return fullId.substring(dotIndex + 1) == bundleId;
+  }
+
+  var foundInAppLinks = false;
+  final applinks = jsonBody['applinks'];
+  if (applinks is Map) {
+    final details = applinks['details'];
+    if (details is List) {
+      foundInAppLinks = details.any(
+        (entry) =>
+            entry is Map &&
+            entry['appID'] is String &&
+            matchesBundle(entry['appID'] as String),
+      );
+    }
+  }
+
+  var foundInWebCred = false;
+  final webcredentials = jsonBody['webcredentials'];
+  if (webcredentials is Map) {
+    final apps = webcredentials['apps'];
+    if (apps is List) {
+      foundInWebCred = apps.any(
+        (entry) => entry is String && matchesBundle(entry),
+      );
+    }
+  }
+
+  if (foundInAppLinks && foundInWebCred) {
+    return Checkpoint(
+      name: 'AASA file check',
+      description:
+          '$uri contains valid entries for applinks.details.appID and webcredentials.apps.',
+      type: CheckpointType.success,
+    );
+  }
+
+  final missing = <String>[];
+  if (!foundInAppLinks) missing.add('applinks.details.appID');
+  if (!foundInWebCred) missing.add('webcredentials.apps');
+
+  return Checkpoint(
+    name: 'AASA file check',
+    description:
+        'Missing expected bundle ID "$bundleId" in ${missing.join(', ')} from $uri',
+    type: CheckpointType.error,
+    documentationLink: DocLinks.ios,
+  );
+}
+
+/// Evaluates parsed assetlinks entries for the given app.
+Checkpoint evaluateAssetLinks(
+  Uri uri,
+  List<dynamic> entries, {
+  required String package,
+  required List<String> fingerprints,
+  required String rpid,
+}) {
+  final expectedFingerprints = fingerprints.map((f) => f.toUpperCase()).toSet();
+
+  var androidValid = false;
+  var webValid = false;
+
+  for (final obj in entries) {
+    if (obj is! Map<String, dynamic>) continue;
+    final target = obj['target'];
+    if (target is! Map<String, dynamic>) continue;
+
+    final namespace = target['namespace'];
+
+    if (namespace == 'android_app' && target['package_name'] == package) {
+      final fps = target['sha256_cert_fingerprints'];
+      if (fps is List &&
+          fps.any(
+            (f) =>
+                f is String && expectedFingerprints.contains(f.toUpperCase()),
+          )) {
+        androidValid = true;
+      }
+    }
+
+    if (namespace == 'web' && target['site'] == 'https://$rpid') {
+      webValid = true;
+    }
+  }
+
+  if (androidValid && webValid) {
+    return Checkpoint(
+      name: 'Asset link file check',
+      description: '$uri contains valid entries for Android and Web.',
+      type: CheckpointType.success,
+    );
+  }
+
+  final missing = <String>[];
+  if (!androidValid) {
+    missing.add('android_app (package or fingerprint mismatch)');
+  }
+  if (!webValid) missing.add('web (site mismatch)');
+
+  return Checkpoint(
+    name: 'Asset link file check',
+    description: 'Missing or invalid entries in $uri: $missing',
+    type: CheckpointType.error,
+    documentationLink: DocLinks.android,
+  );
+}

--- a/packages/passkeys/passkeys_doctor/lib/src/passkeys_doctor.dart
+++ b/packages/passkeys/passkeys_doctor/lib/src/passkeys_doctor.dart
@@ -7,7 +7,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:passkeys_doctor/src/checks.dart';
 import 'package:passkeys_doctor/src/logger.dart';
+import 'package:passkeys_doctor/src/web_script_check.dart';
 import 'package:passkeys_platform_interface/passkeys_platform_interface.dart';
 import 'package:passkeys_platform_interface/types/types.dart';
 
@@ -15,10 +17,8 @@ import '../passkeys_doctor.dart';
 import 'messages.g.dart';
 
 class PasskeysDoctor {
-  final PasskeysPlatform _platform;
-
   PasskeysDoctor() : _platform = PasskeysPlatform.instance {
-    Logger(_streamController.stream.distinct());
+    _logger = Logger(_streamController.stream.distinct());
 
     _checkpoints.addListener(() {
       _streamController.add(
@@ -45,7 +45,9 @@ class PasskeysDoctor {
     });
   }
 
+  final PasskeysPlatform _platform;
   final WebCredentialsApi _api = WebCredentialsApi();
+  late final Logger _logger;
 
   final ValueNotifier<PlatformException?> _lastException = ValueNotifier(null);
   final ValueNotifier<List<Checkpoint>> _checkpoints = ValueNotifier([]);
@@ -54,7 +56,7 @@ class PasskeysDoctor {
 
   Stream<Result> get resultStream => _streamController.stream;
 
-  recordException(PlatformException exception) {
+  void recordException(PlatformException exception) {
     if (exception.code == 'suppressed') {
       return;
     }
@@ -62,25 +64,30 @@ class PasskeysDoctor {
     _lastException.value = exception;
   }
 
-  check(String rpId) async {
-    final List<Checkpoint> checkpoints = [];
+  Future<void> check(String rpId) async {
+    final checkpoints = <Checkpoint>[];
 
     try {
-      checkpoints.add(_checkRpid(rpId));
+      if (kIsWeb) {
+        checkpoints.add(checkRpidValue(rpId, hostname: Uri.base.host));
+        checkpoints.add(_checkWebScript());
+      } else {
+        checkpoints.add(checkRpidValue(rpId));
 
-      if (!kIsWeb) {
-        if (Platform.isIOS) {
-          final iosAvailability =
-              (await _platform.getAvailability()) as AvailabilityTypeIOS;
-          final iosCheck = await _checkIosAvailability(iosAvailability);
-          if (iosCheck != null) {
-            checkpoints.add(iosCheck);
+        if (Platform.isIOS || Platform.isMacOS) {
+          if (Platform.isIOS) {
+            final iosAvailability =
+                (await _platform.getAvailability()) as AvailabilityTypeIOS;
+            final iosCheck = await _checkIosAvailability(iosAvailability);
+            if (iosCheck != null) {
+              checkpoints.add(iosCheck);
+            }
           }
           checkpoints.add(await _checkAASAFile(rpId));
-        }
-
-        if (Platform.isAndroid) {
+        } else if (Platform.isAndroid) {
           checkpoints.add(await _checkAssetLinks(rpId));
+        } else if (Platform.isWindows) {
+          checkpoints.add(await _checkWindows());
         }
       }
     } on DoctorException catch (e) {
@@ -92,67 +99,23 @@ class PasskeysDoctor {
     _checkpoints.value = checkpoints;
   }
 
-  Checkpoint _checkRpid(String rpid) {
-    if (rpid.isEmpty) {
-      throw DoctorException(
-        blockingCheckpoint: Checkpoint(
-          name: 'RPID check',
-          description: 'RPID is not set',
-          type: CheckpointType.error,
-        ),
-      );
-    }
-
-    // If they passed a URL (scheme or any slash), extract host and bail out with suggestion
-    if (rpid.contains('://') || rpid.contains('/')) {
-      try {
-        final uri = Uri.parse(rpid);
-        final host = uri.host.toLowerCase();
-        if (host.isEmpty) throw FormatException();
-
-        throw DoctorException(
-          blockingCheckpoint: Checkpoint(
-            name: 'RPID check',
-            description:
-                'RPID must be just a hostname, not a URL. '
-                'Did you mean "$host"?',
-            type: CheckpointType.error,
-          ),
-        );
-      } catch (_) {
-        throw DoctorException(
-          blockingCheckpoint: Checkpoint(
-            name: 'RPID check',
-            description: 'RPID "$rpid" is not a valid URL or hostname.',
-            type: CheckpointType.error,
-          ),
-        );
-      }
-    }
-
-    if (kIsWeb) {
-      final hostname = Uri.base.host.toLowerCase();
-      final matches = hostname == rpid || hostname.endsWith('.' + rpid);
-
-      if (!matches) {
-        return Checkpoint(
-          name: 'RPID check',
-          description: 'RPID "$rpid" is NOT valid for hostname "$hostname".',
-          type: CheckpointType.error,
-        );
-      }
-
+  Checkpoint _checkWebScript() {
+    if (isPasskeysWebScriptLoaded()) {
       return Checkpoint(
-        name: 'RPID check',
-        description: 'RPID "$rpid" is valid for hostname "$hostname".',
+        name: 'Passkeys JS script check',
+        description: 'The passkeys web SDK (bundle.js) is loaded.',
         type: CheckpointType.success,
       );
     }
 
     return Checkpoint(
-      name: 'RPID check',
-      description: 'RPID is set correctly ("$rpid").',
-      type: CheckpointType.success,
+      name: 'Passkeys JS script check',
+      description:
+          'The passkeys web SDK (bundle.js) is not loaded. Include it in your '
+          'index.html. Releases: '
+          'https://github.com/corbado/flutter-passkeys/releases',
+      type: CheckpointType.error,
+      documentationLink: DocLinks.flutterIntegration,
     );
   }
 
@@ -163,12 +126,13 @@ class PasskeysDoctor {
 
     http.Response response;
     try {
-      response = await http.get(uri).timeout(Duration(seconds: 5));
+      response = await http.get(uri).timeout(const Duration(seconds: 5));
     } catch (e) {
       return Checkpoint(
         name: 'AASA file check',
         description: 'Failed to fetch $uri: $e',
         type: CheckpointType.error,
+        documentationLink: DocLinks.ios,
       );
     }
 
@@ -177,6 +141,7 @@ class PasskeysDoctor {
         name: 'AASA file check',
         description: '$uri not found (HTTP ${response.statusCode}).',
         type: CheckpointType.error,
+        documentationLink: DocLinks.ios,
       );
     }
 
@@ -188,6 +153,7 @@ class PasskeysDoctor {
         description:
             '$uri does not return valid "Content-Type" header: expected "application/json" but received "${contentType ?? 'none'}".',
         type: CheckpointType.error,
+        documentationLink: DocLinks.ios,
       );
     }
 
@@ -199,68 +165,13 @@ class PasskeysDoctor {
         name: 'AASA file check',
         description: '$uri does not return valid JSON: $e',
         type: CheckpointType.error,
+        documentationLink: DocLinks.ios,
       );
     }
 
-    final bundleID = await _getBundleId();
-    final expectedAppID = bundleID;
+    final bundleId = await _getBundleId();
 
-    // Check applinks.details.appID (match bundle ID after the first dot)
-    bool foundInAppLinks = false;
-    if (jsonBody['applinks'] is Map) {
-      final details = (jsonBody['applinks'] as Map)['details'];
-      if (details is List) {
-        foundInAppLinks = details.any((entry) {
-          if (entry is Map && entry['appID'] is String) {
-            final fullId = entry['appID'] as String;
-            final dotIndex = fullId.indexOf('.');
-            if (dotIndex > 0 && dotIndex < fullId.length - 1) {
-              final bundlePart = fullId.substring(dotIndex + 1);
-              return bundlePart == expectedAppID;
-            }
-          }
-          return false;
-        });
-      }
-    }
-
-    // Check webcredentials.apps (same bundle-only match)
-    bool foundInWebCred = false;
-    if (jsonBody['webcredentials'] is Map) {
-      final apps = (jsonBody['webcredentials'] as Map)['apps'];
-      if (apps is List) {
-        foundInWebCred = apps.any((entry) {
-          if (entry is String) {
-            final dotIndex = entry.indexOf('.');
-            if (dotIndex > 0 && dotIndex < entry.length - 1) {
-              final bundlePart = entry.substring(dotIndex + 1);
-              return bundlePart == expectedAppID;
-            }
-          }
-          return false;
-        });
-      }
-    }
-
-    if (foundInAppLinks && foundInWebCred) {
-      return Checkpoint(
-        name: 'AASA file check',
-        description:
-            '$uri contains valid entries for applinks.details.appID and webcredentials.apps.',
-        type: CheckpointType.success,
-      );
-    }
-
-    final missing = <String>[];
-    if (!foundInAppLinks) missing.add('applinks.details.appID');
-    if (!foundInWebCred) missing.add('webcredentials.apps');
-
-    return Checkpoint(
-      name: 'AASA file check',
-      description:
-          'Missing expected bundle ID "$bundleID" in ${missing.join(', ')} from $uri',
-      type: CheckpointType.error,
-    );
+    return evaluateAasa(uri, jsonBody, bundleId);
   }
 
   Future<Checkpoint> _checkAssetLinks(String rpid) async {
@@ -268,12 +179,13 @@ class PasskeysDoctor {
 
     http.Response response;
     try {
-      response = await http.get(uri).timeout(Duration(seconds: 5));
+      response = await http.get(uri).timeout(const Duration(seconds: 5));
     } catch (e) {
       return Checkpoint(
         name: 'Asset link file check',
         description: 'Failed to fetch $uri: $e',
         type: CheckpointType.error,
+        documentationLink: DocLinks.android,
       );
     }
 
@@ -282,6 +194,7 @@ class PasskeysDoctor {
         name: 'Asset link file check',
         description: '$uri not found (HTTP ${response.statusCode}).',
         type: CheckpointType.error,
+        documentationLink: DocLinks.android,
       );
     }
 
@@ -293,6 +206,7 @@ class PasskeysDoctor {
         description:
             '$uri does not return valid "Content-Type" header: expected "application/json" but received "${contentType ?? 'none'}".',
         type: CheckpointType.error,
+        documentationLink: DocLinks.android,
       );
     }
 
@@ -304,54 +218,19 @@ class PasskeysDoctor {
         name: 'Asset link file check',
         description: '$uri does not return valid JSON: $e',
         type: CheckpointType.error,
+        documentationLink: DocLinks.android,
       );
     }
 
     final expectedPackage = await _getBundleId();
     final expectedFingerprints = await _getFingerprints();
 
-    bool androidValid = false;
-    bool webValid = false;
-
-    for (var obj in entries) {
-      if (obj is Map<String, dynamic>) {
-        final target = obj['target'];
-        if (target is Map<String, dynamic>) {
-          final namespace = target['namespace'];
-
-          if (namespace == 'android_app' &&
-              target['package_name'] == expectedPackage) {
-            final fps = target['sha256_cert_fingerprints'];
-            if (fps is List &&
-                fps.any((f) => expectedFingerprints.contains(f))) {
-              androidValid = true;
-            }
-          }
-
-          if (namespace == 'web' && target['site'] == 'https://' + rpid) {
-            webValid = true;
-          }
-        }
-      }
-    }
-
-    if (androidValid && webValid) {
-      return Checkpoint(
-        name: 'Asset link file check',
-        description: '$uri contains valid entries for Android and Web.',
-        type: CheckpointType.success,
-      );
-    }
-
-    final missing = <String>[];
-    if (!androidValid)
-      missing.add('android_app (package or fingerprint mismatch)');
-    if (!webValid) missing.add('web (site mismatch)');
-
-    return Checkpoint(
-      name: 'Asset link file check',
-      description: 'Missing or invalid entries in $uri: $missing',
-      type: CheckpointType.error,
+    return evaluateAssetLinks(
+      uri,
+      entries,
+      package: expectedPackage,
+      fingerprints: expectedFingerprints,
+      rpid: rpid,
     );
   }
 
@@ -366,10 +245,38 @@ class PasskeysDoctor {
         description:
             'FaceID/TouchID is not enabled on your simulator. Please enable it in the simulator settings "Features > Face ID/Touch ID > Enable".',
         type: CheckpointType.error,
+        documentationLink: DocLinks.ios,
       );
     }
 
     return null;
+  }
+
+  Future<Checkpoint> _checkWindows() async {
+    // Windows 10 version 1903 (build 18362) is the first release exposing the
+    // WebAuthn platform API used for passkeys.
+    const minWebAuthnBuild = 18362;
+    final info = await DeviceInfoPlugin().windowsInfo;
+
+    if (info.buildNumber < minWebAuthnBuild) {
+      return Checkpoint(
+        name: 'Windows version check',
+        description:
+            'Windows build ${info.buildNumber} does not support the WebAuthn '
+            'platform API (requires Windows 10 version 1903 / build 18362 or '
+            'newer).',
+        type: CheckpointType.error,
+        documentationLink: DocLinks.flutterIntegration,
+      );
+    }
+
+    return Checkpoint(
+      name: 'Windows version check',
+      description:
+          'Windows build ${info.buildNumber} supports the WebAuthn platform '
+          'API.',
+      type: CheckpointType.success,
+    );
   }
 
   Future<String> _getBundleId() async {
@@ -384,7 +291,9 @@ class PasskeysDoctor {
     return fingerprints;
   }
 
-  void dispose() {
+  Future<void> dispose() async {
+    await _logger.dispose();
+    await _streamController.close();
     _lastException.dispose();
     _checkpoints.dispose();
   }

--- a/packages/passkeys/passkeys_doctor/lib/src/web_script_check.dart
+++ b/packages/passkeys/passkeys_doctor/lib/src/web_script_check.dart
@@ -1,0 +1,2 @@
+export 'web_script_check_stub.dart'
+    if (dart.library.js_interop) 'web_script_check_web.dart';

--- a/packages/passkeys/passkeys_doctor/lib/src/web_script_check_stub.dart
+++ b/packages/passkeys/passkeys_doctor/lib/src/web_script_check_stub.dart
@@ -1,0 +1,3 @@
+/// Non-web fallback. The passkeys web SDK only exists on web, so this is never
+/// called off-web.
+bool isPasskeysWebScriptLoaded() => true;

--- a/packages/passkeys/passkeys_doctor/lib/src/web_script_check_web.dart
+++ b/packages/passkeys/passkeys_doctor/lib/src/web_script_check_web.dart
@@ -1,0 +1,8 @@
+import 'dart:js_interop';
+
+@JS('PasskeyAuthenticator')
+external JSAny? get _passkeyAuthenticator;
+
+/// Whether the passkeys web SDK (`bundle.js`) is loaded, detected by the
+/// presence of the global `PasskeyAuthenticator` object.
+bool isPasskeysWebScriptLoaded() => _passkeyAuthenticator.isDefinedAndNotNull;

--- a/packages/passkeys/passkeys_doctor/pubspec.yaml
+++ b/packages/passkeys/passkeys_doctor/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   passkeys_platform_interface: ^2.8.0
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   pigeon: ^26.3.4
 
 flutter:

--- a/packages/passkeys/passkeys_doctor/test/checks_test.dart
+++ b/packages/passkeys/passkeys_doctor/test/checks_test.dart
@@ -1,0 +1,200 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:passkeys_doctor/passkeys_doctor.dart';
+import 'package:passkeys_doctor/src/checks.dart';
+
+void main() {
+  group('checkRpidValue', () {
+    test('throws when RPID is empty', () {
+      expect(() => checkRpidValue(''), throwsA(isA<DoctorException>()));
+    });
+
+    test('throws with a suggestion when a URL is passed', () {
+      try {
+        checkRpidValue('https://flutter.corbado.io/');
+        fail('expected DoctorException');
+      } on DoctorException catch (e) {
+        expect(e.blockingCheckpoint.type, CheckpointType.error);
+        expect(
+          e.blockingCheckpoint.description,
+          contains('flutter.corbado.io'),
+        );
+      }
+    });
+
+    test('throws when a path-only value is passed', () {
+      expect(() => checkRpidValue('foo/bar'), throwsA(isA<DoctorException>()));
+    });
+
+    test('succeeds for a plain hostname off-web', () {
+      final cp = checkRpidValue('flutter.corbado.io');
+      expect(cp.type, CheckpointType.success);
+    });
+
+    test('matches exact hostname on web', () {
+      final cp = checkRpidValue('corbado.io', hostname: 'corbado.io');
+      expect(cp.type, CheckpointType.success);
+    });
+
+    test('matches a subdomain of the RPID on web', () {
+      final cp = checkRpidValue('corbado.io', hostname: 'app.corbado.io');
+      expect(cp.type, CheckpointType.success);
+    });
+
+    test('fails when hostname does not match the RPID on web', () {
+      final cp = checkRpidValue('corbado.io', hostname: 'example.com');
+      expect(cp.type, CheckpointType.error);
+    });
+
+    test('does not treat a suffix substring as a subdomain match', () {
+      final cp = checkRpidValue('corbado.io', hostname: 'notcorbado.io');
+      expect(cp.type, CheckpointType.error);
+    });
+  });
+
+  group('evaluateAasa', () {
+    final uri = Uri.parse(
+      'https://corbado.io/.well-known/apple-app-site-association',
+    );
+
+    Map<String, dynamic> aasa({
+      required String appLinkId,
+      required String webCredId,
+    }) {
+      return jsonDecode(
+            jsonEncode({
+              'applinks': {
+                'details': [
+                  {'appID': appLinkId},
+                ],
+              },
+              'webcredentials': {
+                'apps': [webCredId],
+              },
+            }),
+          )
+          as Map<String, dynamic>;
+    }
+
+    test('succeeds when both applinks and webcredentials match', () {
+      final cp = evaluateAasa(
+        uri,
+        aasa(
+          appLinkId: 'ABCDE.com.corbado.app',
+          webCredId: 'ABCDE.com.corbado.app',
+        ),
+        'com.corbado.app',
+      );
+      expect(cp.type, CheckpointType.success);
+    });
+
+    test('fails when webcredentials is missing the bundle', () {
+      final cp = evaluateAasa(
+        uri,
+        aasa(appLinkId: 'ABCDE.com.corbado.app', webCredId: 'ABCDE.com.other'),
+        'com.corbado.app',
+      );
+      expect(cp.type, CheckpointType.error);
+      expect(cp.description, contains('webcredentials.apps'));
+    });
+
+    test('matches a bundle id that itself contains dots', () {
+      final cp = evaluateAasa(
+        uri,
+        aasa(
+          appLinkId: 'TEAM.io.corbado.demo.app',
+          webCredId: 'TEAM.io.corbado.demo.app',
+        ),
+        'io.corbado.demo.app',
+      );
+      expect(cp.type, CheckpointType.success);
+    });
+
+    test('fails on a malformed appID with no team prefix', () {
+      final cp = evaluateAasa(
+        uri,
+        aasa(appLinkId: 'com.corbado.app', webCredId: 'com.corbado.app'),
+        'com.corbado.app',
+      );
+      expect(cp.type, CheckpointType.error);
+    });
+  });
+
+  group('evaluateAssetLinks', () {
+    final uri = Uri.parse('https://corbado.io/.well-known/assetlinks.json');
+    const fingerprint = 'F8:90:4E:9A:99:01:71:75';
+
+    List<dynamic> entries({
+      required String package,
+      required String fp,
+      String site = 'https://corbado.io',
+    }) {
+      return jsonDecode(
+            jsonEncode([
+              {
+                'relation': ['delegate_permission/common.get_login_creds'],
+                'target': {
+                  'namespace': 'android_app',
+                  'package_name': package,
+                  'sha256_cert_fingerprints': [fp],
+                },
+              },
+              {
+                'relation': ['delegate_permission/common.get_login_creds'],
+                'target': {'namespace': 'web', 'site': site},
+              },
+            ]),
+          )
+          as List<dynamic>;
+    }
+
+    test('succeeds when android and web entries match', () {
+      final cp = evaluateAssetLinks(
+        uri,
+        entries(package: 'com.corbado.app', fp: fingerprint),
+        package: 'com.corbado.app',
+        fingerprints: [fingerprint],
+        rpid: 'corbado.io',
+      );
+      expect(cp.type, CheckpointType.success);
+    });
+
+    test('matches fingerprints case-insensitively', () {
+      final cp = evaluateAssetLinks(
+        uri,
+        entries(package: 'com.corbado.app', fp: fingerprint.toLowerCase()),
+        package: 'com.corbado.app',
+        fingerprints: [fingerprint],
+        rpid: 'corbado.io',
+      );
+      expect(cp.type, CheckpointType.success);
+    });
+
+    test('fails on a fingerprint mismatch', () {
+      final cp = evaluateAssetLinks(
+        uri,
+        entries(package: 'com.corbado.app', fp: 'AA:BB:CC'),
+        package: 'com.corbado.app',
+        fingerprints: [fingerprint],
+        rpid: 'corbado.io',
+      );
+      expect(cp.type, CheckpointType.error);
+    });
+
+    test('fails when the web site does not match the RPID', () {
+      final cp = evaluateAssetLinks(
+        uri,
+        entries(
+          package: 'com.corbado.app',
+          fp: fingerprint,
+          site: 'https://other.io',
+        ),
+        package: 'com.corbado.app',
+        fingerprints: [fingerprint],
+        rpid: 'corbado.io',
+      );
+      expect(cp.type, CheckpointType.error);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Reviewed `passkeys_doctor` and fixed a production-behavior bug plus several gaps between what the README documents and what the code actually does.

### Fixes
- **Doctor no longer runs when `debugMode` is off.** `PasskeyAuthenticator._doctor` was a non-lazy field, so the `Logger` banner (`--------Doctor--------` / `Doctor started`), stream controllers and listeners were created for **every** consumer, even in production. It's now constructed only when `debugMode` is enabled, and `resultStream` emits nothing when disabled.
- **`dispose()` leaks.** Now closes the `StreamController` and cancels the `Logger` subscription (previously never done).
- **Fingerprint matching** in `assetlinks.json` is now case-insensitive.

### Documented-but-missing behavior
- **Web JS script check** (README §2.3.2) is now implemented, via a conditional `dart:js_interop` import that feature-detects the global `PasskeyAuthenticator` (the object `passkeys_web` requires). Verified with a real `flutter build web`.
- **macOS** now runs the AASA check (previously iOS only, despite `passkeys_darwin` supporting macOS).
- **Windows** now gets a version check for WebAuthn platform API support (Windows 10 1903 / build 18362+).

### Quality
- `documentationLink` is now populated on failing checkpoints (was always `N/A`).
- Extracted RPID/AASA/assetlinks decision logic into pure functions in `checks.dart`.
- Added a unit test suite (`test/checks_test.dart`, 16 tests): subdomain matching, dotted bundle IDs, malformed appIDs, case-insensitive fingerprints, site mismatches.

## Behavior change to note
Consumers who read `resultStream` without passing `debugMode: true` will now get an empty stream. That is the intended behavior (checks never ran for them anyway), but it is a subtle change worth calling out for the changelog.

## Verification
- `melos format --set-exit-if-changed` → clean
- `melos analyze --fatal-infos` → no issues
- `passkeys_doctor` tests: 16/16 pass; `passkeys` tests still pass
- `flutter build web` on the example app succeeds

Versions/CHANGELOGs are intentionally left untouched since they are generated at release time from conventional commits.