### PR TITLE
fix(passkeys_android): stop applying the Kotlin Gradle Plugin when Kotlin is already provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ gradlew.bat
 # FVM Version Cache
 .fvm/
 .fvmrc
+
+# LLM
+.claude/


### PR DESCRIPTION
Closes #308

## What

Flutter warns about plugins that apply the Kotlin Gradle Plugin (KGP) and will fail such builds in a future release:

```
WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): ..., passkeys_android, ...
```

The plugin already guarded its `apply plugin: 'kotlin-android'` behind a runtime check of `android.builtInKotlin`, but Flutter detects the apply statement by scanning the build script text, so the warning still fired.

Kotlin support now comes from the app whenever possible. AGP 9 provides it built in, and Flutter 3.44+ applies KGP to plugin projects on older setups. The plugin only applies KGP itself when neither has already registered the `kotlin` extension, which keeps Flutter versions before 3.44 building without raising the minimum SDK.

## Verification

All builds used this branch's `passkeys_android`:

| Setup | Result |
|---|---|
| `passkeys` example, Flutter 3.47.3, AGP 9.0.1, `android.builtInKotlin=false` | Builds. `passkeys_android` no longer listed in the KGP warning. |
| New app, Flutter 3.47.3, AGP 9.1.0, `android.builtInKotlin=true` | Builds with no warning. AGP supplied the Kotlin extension and the plugin skipped KGP. |
| New app, Flutter 3.35.7, AGP 8.9.1 | Builds. No shim exists there, so the plugin applied KGP itself. |

The `passkeys` example stays on `android.builtInKotlin=false` because device_info_plus, package_info_plus, flutter_localization and patrol at their currently resolved versions still apply KGP.